### PR TITLE
新規遠征に対応しました。

### DIFF
--- a/ExpeditionListPlugin.sln
+++ b/ExpeditionListPlugin.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.27130.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExpeditionListPlugin", "ExpeditionListPlugin\ExpeditionListPlugin.csproj", "{C9BA0ACE-71D0-434C-82A9-0C8F7CEC1769}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExpeditionListPluginTests", "ExpeditionListPluginTests\ExpeditionListPluginTests.csproj", "{ED709ABD-DC0B-404F-8B10-CFE5A79A50EE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,8 +17,15 @@ Global
 		{C9BA0ACE-71D0-434C-82A9-0C8F7CEC1769}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C9BA0ACE-71D0-434C-82A9-0C8F7CEC1769}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C9BA0ACE-71D0-434C-82A9-0C8F7CEC1769}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ED709ABD-DC0B-404F-8B10-CFE5A79A50EE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ED709ABD-DC0B-404F-8B10-CFE5A79A50EE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ED709ABD-DC0B-404F-8B10-CFE5A79A50EE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ED709ABD-DC0B-404F-8B10-CFE5A79A50EE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {72675F17-E8A8-4BDD-8F05-FC7A86F70240}
 	EndGlobalSection
 EndGlobal

--- a/ExpeditionListPlugin/ExpeditionInfo.cs
+++ b/ExpeditionListPlugin/ExpeditionInfo.cs
@@ -8,24 +8,64 @@ namespace ExpeditionListPlugin
 {
     public class ExpeditionInfo
     {
+        /// <summary>
+        /// 駆逐艦
+        /// </summary>
         public static readonly string DESTROYER = "(?<駆>駆逐艦)";
 
+        /// <summary>
+        /// 軽巡洋艦
+        /// </summary>
         public static readonly string LIGHTCRUISER = "(?<軽>軽巡洋艦)";
 
+        /// <summary>
+        /// 軽巡洋艦
+        /// </summary>
         public static readonly string HEAVYCRUISER = "(?<重>重巡洋艦)";
 
+        /// <summary>
+        /// 航空戦艦
+        /// </summary>
         public static readonly string AVIATIONBATTLESHIP = "(?<航戦>航空戦艦)";
 
+        /// <summary>
+        /// 潜水艦
+        /// </summary>
         public static readonly string SUBMARINE = "(?<潜>潜水艦|潜水空母)";
 
+        /// <summary>
+        /// 練習巡洋艦
+        /// </summary>
         public static readonly string TRAININGCRUISER = "(?<練>練習巡洋艦)";
 
+        /// <summary>
+        /// 水上機母艦
+        /// </summary>
         public static readonly string SEAPLANETENDER = "(?<水母>水上機母艦)";
 
+        /// <summary>
+        /// 潜水母艦
+        /// </summary>
         public static readonly string SUBMARINETENDER = "(?<潜母艦>潜水母艦)";
-        
+
+        /// <summary>
+        /// 空母
+        /// </summary>
         public static readonly string AIRCRAFTCARRIER = "(?<空母>正規空母|装甲空母|軽空母|水上機母艦)";
 
+        /// <summary>
+        /// 海防艦
+        /// </summary>
+        public static readonly string ESCORT = "(?<海防>海防艦)";
+
+        /// <summary>
+        /// 護衛空母
+        /// </summary>
+        public static readonly string ESCORTECARRIER = "(?<護母>護衛空母)";
+
+        /// <summary>
+        /// ドラム缶
+        /// </summary>
         public static readonly string DRUMCANISTER = "ドラム缶(輸送用)";
 
         public string Area { get; set; }
@@ -70,7 +110,7 @@ namespace ExpeditionListPlugin
                         list.Add(match.Groups[1].Value + pair.Value);
                     }
                 }
-                return string.Join(" ",list);
+                return string.Join(" ", list);
             }
         }
         public string RequireDrum
@@ -81,6 +121,33 @@ namespace ExpeditionListPlugin
                 return RequireItemShipNum[DRUMCANISTER] + "隻 " + RequireItemNum[DRUMCANISTER] + "個";
             }
         }
+
+        /// <summary>
+        /// 必要合算艦種
+        /// </summary>
+        public string[] RequireSumShipType { get; set; }
+
+        /// <summary>
+        /// 必要合算艦種数
+        /// </summary>
+        public int RequireSumShipTypeNum { get; set; }
+
+        /// <summary>
+        /// 合計対空値
+        /// </summary>
+        public int? SumAA { get; set; }
+
+        /// <summary>
+        /// 合計対潜値
+        /// </summary>
+        public int? SumASW { get; set; }
+        //
+        /// <summary>
+        /// 合計索敵値
+        /// </summary>
+        public int? SumViewRange { get; set; }
+
+
         public int? Fuel { get; set; }
         public int? Ammunition { get; set; }
         public int? Bauxite { get; set; }
@@ -88,6 +155,9 @@ namespace ExpeditionListPlugin
         public int? InstantBuildMaterials { get; set; }
         public int? InstantRepairMaterials { get; set; }
         public int? DevelopmentMaterials { get; set; }
+        /// <summary>
+        /// 家具箱
+        /// </summary>
         public string FurnitureBox { get; set; }
         public bool isFuelNull { get { return Fuel == null; } }
         public bool isAmmunitionNull { get { return Ammunition == null; } }
@@ -105,6 +175,10 @@ namespace ExpeditionListPlugin
             new ExpeditionInfo {Area="鎮守", EName="観艦式予行", Time="01:00", Lv=5,ShipNum=6, Steel=50, Bauxite=30, InstantBuildMaterials=1},
             new ExpeditionInfo {Area="鎮守", EName="観艦式", Time="03:00", Lv=6, ShipNum=6, Fuel=50, Ammunition=100, Steel=50, Bauxite=50, InstantBuildMaterials=2, DevelopmentMaterials=1},
 
+            new ExpeditionInfo {Area="鎮守", EName="兵站強化任務", Time="00:25", Lv=5, ShipNum=4, Fuel=45, Ammunition=45, RequireSumShipType=new string[]{ DESTROYER , ESCORT }, RequireSumShipTypeNum = 3 },
+            new ExpeditionInfo {Area="鎮守", EName="海峡警備行動", Time="00:55", Lv=20, ShipNum=4, Fuel=70, Ammunition=40,Bauxite=10,DevelopmentMaterials=1,InstantRepairMaterials=1, RequireSumShipType=new string[]{ DESTROYER , ESCORT }, RequireSumShipTypeNum = 4 , SumAA=70, SumASW=180},
+            new ExpeditionInfo {Area="鎮守", EName="長時間対潜警戒", Time="02:15", Lv=35,SumLv=185, ShipNum=5, Fuel=120, Steel=60,Bauxite=60,InstantRepairMaterials=1,DevelopmentMaterials=2,RequireShipType=new Dictionary<string, int>() { { LIGHTCRUISER, 1 }}, RequireSumShipType=new string[]{ DESTROYER , ESCORT }, RequireSumShipTypeNum =3 ,SumASW=280 },
+
             new ExpeditionInfo {Area="南西", EName="タンカー護衛任務", Time="04:00", Lv=3, RequireShipType=new Dictionary<string, int>() { { LIGHTCRUISER, 1 }, {DESTROYER, 2 } }, ShipNum=4, Fuel=350, InstantRepairMaterials=2, FurnitureBox="小1"},
             new ExpeditionInfo {Area="南西", EName="強行偵察任務", Time="01:30", Lv=3, RequireShipType=new Dictionary<string, int>() { { LIGHTCRUISER, 2 } }, ShipNum=3, Ammunition=50, Bauxite=30, InstantRepairMaterials=1, InstantBuildMaterials=1},
             new ExpeditionInfo {Area="南西", EName="ボーキサイト輸送任務", Time="05:00", Lv=6, RequireShipType=new Dictionary<string, int>() { {DESTROYER, 2 } }, ShipNum=4, Bauxite=250, InstantRepairMaterials=1, FurnitureBox="小1"},
@@ -113,6 +187,8 @@ namespace ExpeditionListPlugin
             new ExpeditionInfo {Area="南西", EName="包囲陸戦隊撤収作戦", Time="06:00", Lv=6, RequireShipType=new Dictionary<string, int>() { { LIGHTCRUISER, 1 }, {DESTROYER, 3 } }, ShipNum=6, Ammunition=240, Steel=200, InstantRepairMaterials=1, DevelopmentMaterials=1},
             new ExpeditionInfo {Area="南西", EName="囮機動部隊支援作戦", Time="12:00", Lv=8, RequireShipType=new Dictionary<string, int>() { { AIRCRAFTCARRIER, 2 }, {DESTROYER, 2 } }, ShipNum=6, Steel=300, Bauxite=400, DevelopmentMaterials=1, FurnitureBox="大1"},
             new ExpeditionInfo {Area="南西", EName="艦隊決戦援護作戦", Time="15:00", Lv=10, RequireShipType=new Dictionary<string, int>() { { LIGHTCRUISER, 1 }, {DESTROYER, 2 } }, ShipNum=6, Fuel=500, Ammunition=500, Steel=200, Bauxite=200, InstantBuildMaterials=2, DevelopmentMaterials=2},
+
+            new ExpeditionInfo {Area="南西", EName="南西方面航空偵察作戦", Time="00:35", Lv=40,SumLv=150, ShipNum=6, Steel=10,Bauxite=30,InstantRepairMaterials=1,FurnitureBox="小1", RequireShipType =new Dictionary<string, int>() { { SEAPLANETENDER, 1 },{ LIGHTCRUISER, 1 },{ DESTROYER,2} }, SumAA=200,SumASW=200,SumViewRange=140 },
 
             new ExpeditionInfo {Area="北方", EName="敵地偵察作戦", Time="00:45", Lv=20, RequireShipType=new Dictionary<string, int>() { { LIGHTCRUISER, 1 }, {DESTROYER, 3 } }, ShipNum=6, Fuel=70, Ammunition=70, Steel=50},
             new ExpeditionInfo {Area="北方", EName="航空機輸送作戦", Time="05:00", Lv=15, RequireShipType=new Dictionary<string, int>() { { AIRCRAFTCARRIER, 1 }, {DESTROYER, 3 } }, ShipNum=6, Steel=300, Bauxite=100, InstantRepairMaterials=1},
@@ -157,7 +233,11 @@ namespace ExpeditionListPlugin
         {
             return CheckShipNum(index) && FlagshipLvCheck(index) && SumLvCheck(index)
                         && RequireShipTypeCheck(index) && RequireItemCheck(index)
-                        && FlagShipTypeCheck(index);
+                        && FlagShipTypeCheck(index)
+                        && RequireSumShipTypeCheck(index)
+                        && SumAACheck(index)
+                        && SumASWCheck(index)
+                        && SumViewRangeCheck(index);
         }
 
         /// <summary>
@@ -222,7 +302,7 @@ namespace ExpeditionListPlugin
         private bool RequireItemCheck(int index)
         {
             if (null == RequireItemNum || null == RequireItemShipNum) return true;
-            foreach(KeyValuePair<string, int> pair in RequireItemShipNum)
+            foreach (KeyValuePair<string, int> pair in RequireItemShipNum)
             {
                 int shipNum = KanColleClient.Current.Homeport.Organization.Fleets[index].Ships.Where(
                     ship => ship.EquippedItems.Any(
@@ -263,6 +343,66 @@ namespace ExpeditionListPlugin
             var match = regexp.Match(shiptype.Name);
 
             return match.Success;
+        }
+
+        /// <summary>
+        /// 必要合算艦種のチェック（駆または海防合わせて3隻というようなのに使用）
+        /// </summary>
+        /// <param name="index">The index.</param>
+        /// <returns></returns>
+        private bool RequireSumShipTypeCheck(int index)
+        {
+            //必要合算艦種が設定されていない場合は自動成功
+            if (null == RequireSumShipType) return true;
+
+            int sum = 0;
+            foreach (var siptype in RequireSumShipType)
+            {
+                Regex re = new Regex(siptype);
+                sum += KanColleClient.Current.Homeport.Organization.Fleets[index].Ships
+                     .Where(fleet => re.Match(fleet.Info.ShipType.Name).Success).Count();
+
+                if (sum >= RequireSumShipTypeNum)
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// 合計対空値のチェック
+        /// </summary>
+        /// <param name="index">The index.</param>
+        /// <returns></returns>
+        private bool SumAACheck(int index)
+        {
+            if (null == SumAA) return true;
+
+            return KanColleClient.Current.Homeport.Organization.Fleets[index].Ships.Select(s => s.AA).Sum(s => s.Current) >= SumAA;
+        }
+
+        /// <summary>
+        /// 合計対潜値のチェック
+        /// </summary>
+        /// <param name="index">The index.</param>
+        /// <returns></returns>
+        private bool SumASWCheck(int index)
+        {
+            if (null == SumASW) return true;
+            //南西方面航空偵察作戦の 但し水偵・水爆・飛行艇の対潜値は無効 はまだチェックしない
+            return KanColleClient.Current.Homeport.Organization.Fleets[index].Ships.Select(s => s.ASW).Sum() >= SumASW;
+        }
+
+        /// <summary>
+        /// 合計索敵値のチェック
+        /// </summary>
+        /// <param name="index">The index.</param>
+        /// <returns></returns>
+        private bool SumViewRangeCheck(int index)
+        {
+            if (null == SumViewRange) return true;
+
+            return KanColleClient.Current.Homeport.Organization.Fleets[index].Ships.Select(s => s.ViewRange).Sum() >= SumViewRange;
         }
     }
 }

--- a/ExpeditionListPlugin/ExpeditionInfo.cs
+++ b/ExpeditionListPlugin/ExpeditionInfo.cs
@@ -160,11 +160,21 @@ namespace ExpeditionListPlugin
                         && FlagShipTypeCheck(index);
         }
 
+        /// <summary>
+        /// 艦数チェック
+        /// </summary>
+        /// <param name="index">The index.</param>
+        /// <returns></returns>
         private bool CheckShipNum(int index)
         {
             return KanColleClient.Current.Homeport.Organization.Fleets[index].Ships.Length >= ShipNum;
         }
 
+        /// <summary>
+        /// 旗艦Lvチェック
+        /// </summary>
+        /// <param name="index">The index.</param>
+        /// <returns></returns>
         private bool FlagshipLvCheck(int index)
         {
             if (KanColleClient.Current.Homeport.Organization.Fleets[index].Ships.Length == 0) return false;
@@ -172,6 +182,11 @@ namespace ExpeditionListPlugin
             return KanColleClient.Current.Homeport.Organization.Fleets[index].Ships.First().Level >= Lv;
         }
 
+        /// <summary>
+        /// 合計Lvチェック
+        /// </summary>
+        /// <param name="index">The index.</param>
+        /// <returns></returns>
         private bool SumLvCheck(int index)
         {
             if (null == SumLv) return true;
@@ -179,6 +194,11 @@ namespace ExpeditionListPlugin
             return KanColleClient.Current.Homeport.Organization.Fleets[index].Ships.Select(s => s.Level).Sum() >= SumLv;
         }
 
+        /// <summary>
+        /// 艦種チェック
+        /// </summary>
+        /// <param name="index">The index.</param>
+        /// <returns></returns>
         private bool RequireShipTypeCheck(int index)
         {
             if (null == RequireShipType) return true;
@@ -194,6 +214,11 @@ namespace ExpeditionListPlugin
             return true;
         }
 
+        /// <summary>
+        /// 装備のチェック
+        /// </summary>
+        /// <param name="index">The index.</param>
+        /// <returns></returns>
         private bool RequireItemCheck(int index)
         {
             if (null == RequireItemNum || null == RequireItemShipNum) return true;
@@ -222,6 +247,11 @@ namespace ExpeditionListPlugin
             return true;
         }
 
+        /// <summary>
+        /// 旗艦の艦種チェック
+        /// </summary>
+        /// <param name="index">The index.</param>
+        /// <returns></returns>
         private bool FlagShipTypeCheck(int index)
         {
             if (null == FlagShipType) return true;

--- a/ExpeditionListPlugin/ExpeditionInfo.cs
+++ b/ExpeditionListPlugin/ExpeditionInfo.cs
@@ -78,7 +78,13 @@ namespace ExpeditionListPlugin
         public int Lv { get; set; }
         public int? SumLv { get; set; }
         public int ShipNum { get; set; }
-        public Dictionary<string, int> RequireShipType { get; set; }
+        /// <summary>
+        /// 必要艦種
+        /// </summary>
+        /// <value>
+        /// 必要艦種名と数
+        /// </value>
+        public Dictionary<string, int>[] RequireShipType { get; set; }
         public Dictionary<string, int> RequireItemNum { get; set; }
         public Dictionary<string, int> RequireItemShipNum { get; set; }
         public string FlagShipType { get; set; }
@@ -102,7 +108,7 @@ namespace ExpeditionListPlugin
 
                 Regex re = new Regex("<(.+)>");
                 var list = new List<string>();
-                foreach (KeyValuePair<string, int> pair in RequireShipType)
+                foreach (KeyValuePair<string, int> pair in RequireShipType.First())
                 {
                     String regexText = pair.Key;
                     Match match = re.Match(regexText);
@@ -142,7 +148,7 @@ namespace ExpeditionListPlugin
         /// 合計対潜値
         /// </summary>
         public int? SumASW { get; set; }
-        
+
         /// <summary>
         /// 合計索敵値
         /// </summary>
@@ -155,7 +161,7 @@ namespace ExpeditionListPlugin
         public int? InstantBuildMaterials { get; set; }
         public int? InstantRepairMaterials { get; set; }
         public int? DevelopmentMaterials { get; set; }
-        
+
         /// <summary>
         /// 家具箱
         /// </summary>
@@ -171,51 +177,72 @@ namespace ExpeditionListPlugin
             new ExpeditionInfo {Area="鎮守", EName="練習航海", Time="00:15", Lv=1, ShipNum=2, Ammunition=30},
             new ExpeditionInfo {Area="鎮守", EName="長距離練習航海", Time="00:30", Lv=2, ShipNum=4, Ammunition=100, Steel=30, InstantRepairMaterials=1},
             new ExpeditionInfo {Area="鎮守", EName="警備任務", Time="00:20", Lv=3, ShipNum=3, Fuel=30, Ammunition=30, Steel=40},
-            new ExpeditionInfo {Area="鎮守", EName="対潜警戒任務", Time="00:50", Lv=3, RequireShipType=new Dictionary<string, int>() { { LIGHTCRUISER, 1 }, {DESTROYER, 2 } }, ShipNum=3, Ammunition=60, InstantRepairMaterials=1, FurnitureBox="小1"},
-            new ExpeditionInfo {Area="鎮守", EName="海上護衛任務", Time="01:30", Lv=3, RequireShipType=new Dictionary<string, int>() { { LIGHTCRUISER, 1 }, {DESTROYER, 2 } }, ShipNum=4, Fuel=200, Ammunition=200, Steel=20, Bauxite=20, },
+            new ExpeditionInfo {Area="鎮守", EName="対潜警戒任務", Time="00:50", Lv=3, RequireShipType=new[] {
+             new Dictionary<string, int> { { LIGHTCRUISER, 1 }, { DESTROYER, 2 } },
+             new Dictionary<string, int> { { DESTROYER, 1 },{ ESCORT ,3 } } ,
+             new Dictionary<string, int> { { LIGHTCRUISER, 1 },{ ESCORT ,2 } }, 
+             new Dictionary<string, int> { { TRAININGCRUISER, 1 }, { ESCORT, 2 } },
+             new Dictionary<string, int> { { ESCORTECARRIER, 1 }, { ESCORT, 2 } },
+             new Dictionary<string, int> { { ESCORTECARRIER, 1 }, { DESTROYER, 2 } }
+            }, ShipNum=3, Ammunition=60, InstantRepairMaterials=1, FurnitureBox="小1"},
+            new ExpeditionInfo {Area="鎮守", EName="海上護衛任務", Time="01:30", Lv=3, RequireShipType=new[] {
+             new Dictionary<string, int> { { LIGHTCRUISER, 1 }, { DESTROYER, 2 } },
+             new Dictionary<string, int> { { DESTROYER, 1 },{ ESCORT ,3 } } ,
+             new Dictionary<string, int> { { LIGHTCRUISER, 1 },{ ESCORT ,2 } },
+             new Dictionary<string, int> { { TRAININGCRUISER, 1 }, { ESCORT, 2 } },
+             new Dictionary<string, int> { { ESCORTECARRIER, 1 }, { ESCORT, 2 } },
+             new Dictionary<string, int> { { ESCORTECARRIER, 1 }, { DESTROYER, 2 } }
+            }, ShipNum=4, Fuel=200, Ammunition=200, Steel=20, Bauxite=20, },
             new ExpeditionInfo {Area="鎮守", EName="防空射撃演習", Time="00:40", Lv=4, ShipNum=4, Bauxite=80, FurnitureBox="小1"},
             new ExpeditionInfo {Area="鎮守", EName="観艦式予行", Time="01:00", Lv=5,ShipNum=6, Steel=50, Bauxite=30, InstantBuildMaterials=1},
             new ExpeditionInfo {Area="鎮守", EName="観艦式", Time="03:00", Lv=6, ShipNum=6, Fuel=50, Ammunition=100, Steel=50, Bauxite=50, InstantBuildMaterials=2, DevelopmentMaterials=1},
 
             new ExpeditionInfo {Area="鎮守", EName="兵站強化任務", Time="00:25", Lv=5, ShipNum=4, Fuel=45, Ammunition=45, RequireSumShipType=new string[]{ DESTROYER , ESCORT }, RequireSumShipTypeNum = 3 },
-            new ExpeditionInfo {Area="鎮守", EName="海峡警備行動", Time="00:55", Lv=20, ShipNum=4, Fuel=70, Ammunition=40,Bauxite=10,DevelopmentMaterials=1,InstantRepairMaterials=1, RequireSumShipType=new string[]{ DESTROYER , ESCORT }, RequireSumShipTypeNum = 4 , SumAA=70, SumASW=180},
-            new ExpeditionInfo {Area="鎮守", EName="長時間対潜警戒", Time="02:15", Lv=35,SumLv=185, ShipNum=5, Fuel=120, Steel=60,Bauxite=60,InstantRepairMaterials=1,DevelopmentMaterials=2,RequireShipType=new Dictionary<string, int>() { { LIGHTCRUISER, 1 }}, RequireSumShipType=new string[]{ DESTROYER , ESCORT }, RequireSumShipTypeNum =3 ,SumASW=280 },
+            new ExpeditionInfo {Area="鎮守", EName="海峡警備行動", Time="00:55", Lv=20, ShipNum=4, Fuel=70, Ammunition=40, Bauxite=10,DevelopmentMaterials=1, InstantRepairMaterials=1, RequireSumShipType=new string[]{ DESTROYER , ESCORT }, RequireSumShipTypeNum = 4 , SumAA=70, SumASW=180},
+            new ExpeditionInfo {Area="鎮守", EName="長時間対潜警戒", Time="02:15", Lv=35,SumLv=185, ShipNum=5, Fuel=120, Steel=60,Bauxite=60, InstantRepairMaterials=1, DevelopmentMaterials=2, RequireShipType=new[] {new Dictionary<string, int>() { { LIGHTCRUISER, 1 } } }, RequireSumShipType=new string[]{ DESTROYER , ESCORT }, RequireSumShipTypeNum =3 ,SumASW=280 },
 
-            new ExpeditionInfo {Area="南西", EName="タンカー護衛任務", Time="04:00", Lv=3, RequireShipType=new Dictionary<string, int>() { { LIGHTCRUISER, 1 }, {DESTROYER, 2 } }, ShipNum=4, Fuel=350, InstantRepairMaterials=2, FurnitureBox="小1"},
-            new ExpeditionInfo {Area="南西", EName="強行偵察任務", Time="01:30", Lv=3, RequireShipType=new Dictionary<string, int>() { { LIGHTCRUISER, 2 } }, ShipNum=3, Ammunition=50, Bauxite=30, InstantRepairMaterials=1, InstantBuildMaterials=1},
-            new ExpeditionInfo {Area="南西", EName="ボーキサイト輸送任務", Time="05:00", Lv=6, RequireShipType=new Dictionary<string, int>() { {DESTROYER, 2 } }, ShipNum=4, Bauxite=250, InstantRepairMaterials=1, FurnitureBox="小1"},
-            new ExpeditionInfo {Area="南西", EName="資源輸送任務", Time="08:00", Lv=4, RequireShipType=new Dictionary<string, int>() { {DESTROYER, 2 } }, ShipNum=4, Ammunition=250, Steel=200, DevelopmentMaterials=1, FurnitureBox="中1"},
-            new ExpeditionInfo {Area="南西", EName="鼠輸送作戦", Time="04:00", Lv=5, RequireShipType=new Dictionary<string, int>() { { LIGHTCRUISER, 1 }, {DESTROYER, 4 } }, ShipNum=6, Fuel=240, Ammunition=300, InstantRepairMaterials=2, FurnitureBox="小1"},
-            new ExpeditionInfo {Area="南西", EName="包囲陸戦隊撤収作戦", Time="06:00", Lv=6, RequireShipType=new Dictionary<string, int>() { { LIGHTCRUISER, 1 }, {DESTROYER, 3 } }, ShipNum=6, Ammunition=240, Steel=200, InstantRepairMaterials=1, DevelopmentMaterials=1},
-            new ExpeditionInfo {Area="南西", EName="囮機動部隊支援作戦", Time="12:00", Lv=8, RequireShipType=new Dictionary<string, int>() { { AIRCRAFTCARRIER, 2 }, {DESTROYER, 2 } }, ShipNum=6, Steel=300, Bauxite=400, DevelopmentMaterials=1, FurnitureBox="大1"},
-            new ExpeditionInfo {Area="南西", EName="艦隊決戦援護作戦", Time="15:00", Lv=10, RequireShipType=new Dictionary<string, int>() { { LIGHTCRUISER, 1 }, {DESTROYER, 2 } }, ShipNum=6, Fuel=500, Ammunition=500, Steel=200, Bauxite=200, InstantBuildMaterials=2, DevelopmentMaterials=2},
+            new ExpeditionInfo {Area="南西", EName="タンカー護衛任務", Time="04:00", Lv=3, RequireShipType=new[] {
+             new Dictionary<string, int> { { LIGHTCRUISER, 1 }, { DESTROYER, 2 } },
+             new Dictionary<string, int> { { DESTROYER, 1 },{ ESCORT ,3 } } ,
+             new Dictionary<string, int> { { LIGHTCRUISER, 1 },{ ESCORT ,2 } },
+             new Dictionary<string, int> { { TRAININGCRUISER, 1 }, { ESCORT, 2 } },
+             new Dictionary<string, int> { { ESCORTECARRIER, 1 }, { ESCORT, 2 } },
+             new Dictionary<string, int> { { ESCORTECARRIER, 1 }, { DESTROYER, 2 } }
+            }, ShipNum=4, Fuel=350, InstantRepairMaterials=2, FurnitureBox="小1"},
+            new ExpeditionInfo {Area="南西", EName="強行偵察任務", Time="01:30", Lv=3, RequireShipType=new[] { new Dictionary<string, int> { { LIGHTCRUISER, 2 } } }, ShipNum=3, Ammunition=50, Bauxite=30, InstantRepairMaterials=1, InstantBuildMaterials=1},
+            new ExpeditionInfo {Area="南西", EName="ボーキサイト輸送任務", Time="05:00", Lv=6, RequireShipType=new[] { new Dictionary<string, int> { {DESTROYER, 2 } } }, ShipNum=4, Bauxite=250, InstantRepairMaterials=1, FurnitureBox="小1"},
+            new ExpeditionInfo {Area="南西", EName="資源輸送任務", Time="08:00", Lv=4, RequireShipType=new[] { new Dictionary<string, int> { { DESTROYER, 2 } } }, ShipNum=4, Ammunition=250, Steel=200, DevelopmentMaterials=1, FurnitureBox="中1"},
+            new ExpeditionInfo {Area="南西", EName="鼠輸送作戦", Time="04:00", Lv=5, RequireShipType=new[] { new Dictionary<string, int> { { LIGHTCRUISER, 1 } , {DESTROYER, 4 } } }, ShipNum=6, Fuel=240, Ammunition=300, InstantRepairMaterials=2, FurnitureBox="小1"},
+            new ExpeditionInfo {Area="南西", EName="包囲陸戦隊撤収作戦", Time="06:00", Lv=6, RequireShipType=new[] { new Dictionary<string, int> { { LIGHTCRUISER, 1 } , {DESTROYER, 3 } } }, ShipNum=6, Ammunition=240, Steel=200, InstantRepairMaterials=1, DevelopmentMaterials=1},
+            new ExpeditionInfo {Area="南西", EName="囮機動部隊支援作戦", Time="12:00", Lv=8, RequireShipType=new[] { new Dictionary<string, int> { { AIRCRAFTCARRIER, 2 }, {DESTROYER, 2 } } }, ShipNum=6, Steel=300, Bauxite=400, DevelopmentMaterials=1, FurnitureBox="大1"},
+            new ExpeditionInfo {Area="南西", EName="艦隊決戦援護作戦", Time="15:00", Lv=10, RequireShipType=new[] { new Dictionary<string, int> { { LIGHTCRUISER, 1 }, {DESTROYER, 2 } } }, ShipNum=6, Fuel=500, Ammunition=500, Steel=200, Bauxite=200, InstantBuildMaterials=2, DevelopmentMaterials=2},
 
-            new ExpeditionInfo {Area="南西", EName="南西方面航空偵察作戦", Time="00:35", Lv=40,SumLv=150, ShipNum=6, Steel=10,Bauxite=30,InstantRepairMaterials=1,FurnitureBox="小1", RequireShipType =new Dictionary<string, int>() { { SEAPLANETENDER, 1 },{ LIGHTCRUISER, 1 },{ DESTROYER,2} }, SumAA=200,SumASW=200,SumViewRange=140 },
+            new ExpeditionInfo {Area="南西", EName="南西方面航空偵察作戦", Time="00:35", Lv=40,SumLv=150, ShipNum=6, Steel=10,Bauxite=30,InstantRepairMaterials=1,FurnitureBox="小1", RequireShipType =new[] { new Dictionary<string, int>() { { SEAPLANETENDER, 1 },{ LIGHTCRUISER, 1 },{ DESTROYER,2} } }, SumAA=200,SumASW=200,SumViewRange=140 },
 
-            new ExpeditionInfo {Area="北方", EName="敵地偵察作戦", Time="00:45", Lv=20, RequireShipType=new Dictionary<string, int>() { { LIGHTCRUISER, 1 }, {DESTROYER, 3 } }, ShipNum=6, Fuel=70, Ammunition=70, Steel=50},
-            new ExpeditionInfo {Area="北方", EName="航空機輸送作戦", Time="05:00", Lv=15, RequireShipType=new Dictionary<string, int>() { { AIRCRAFTCARRIER, 1 }, {DESTROYER, 3 } }, ShipNum=6, Steel=300, Bauxite=100, InstantRepairMaterials=1},
-            new ExpeditionInfo {Area="北方", EName="北号作戦", Time="06:00", Lv=20, RequireShipType=new Dictionary<string, int>() { { AVIATIONBATTLESHIP, 2 }, {DESTROYER, 2 } }, ShipNum=6, Fuel=400, Steel=50, Bauxite=30, DevelopmentMaterials=1, FurnitureBox="小1"},
-            new ExpeditionInfo {Area="北方", EName="潜水艦哨戒任務",  Time="02:00", RequireShipType=new Dictionary<string, int>() { { SUBMARINE, 1 }, { LIGHTCRUISER, 1 } }, Lv=1, ShipNum=2, Steel=150, DevelopmentMaterials=1, FurnitureBox="小1"},
-            new ExpeditionInfo {Area="北方", EName="北方鼠輸送作戦", Time="02:20", Lv=15, SumLv=30, RequireItemNum=new Dictionary<string, int>() { { DRUMCANISTER, 3 } }, RequireItemShipNum=new Dictionary<string, int>() { { DRUMCANISTER, 3 } }, RequireShipType=new Dictionary<string, int>() { { LIGHTCRUISER, 1 }, {DESTROYER, 4 } }, ShipNum=5, Fuel=320, Ammunition=270, FurnitureBox="小1"},
-            new ExpeditionInfo {Area="北方", EName="艦隊演習", Time="03:00", Lv=30, SumLv=45, RequireShipType=new Dictionary<string, int>() { { HEAVYCRUISER, 1 }, { LIGHTCRUISER, 1 }, {DESTROYER, 2 } }, ShipNum=6, Ammunition=10},
-            new ExpeditionInfo {Area="北方", EName="航空戦艦運用演習", Time="04:00", Lv=50, SumLv=200, RequireShipType=new Dictionary<string, int>() { { AVIATIONBATTLESHIP, 2 }, {DESTROYER, 2 } }, ShipNum=6, Ammunition=20, Bauxite=100},
-            new ExpeditionInfo {Area="北方", EName="北方航路海上護衛", Time="08:20", Lv=50, SumLv=200, RequireShipType=new Dictionary<string, int>() { { LIGHTCRUISER, 1 }, {DESTROYER, 4 } }, ShipNum=6, Fuel=500, Bauxite=150, InstantRepairMaterials=1, DevelopmentMaterials=2, FlagShipType = LIGHTCRUISER},
+            new ExpeditionInfo {Area="北方", EName="敵地偵察作戦", Time="00:45", Lv=20, RequireShipType=new[] { new Dictionary<string, int> { { LIGHTCRUISER, 1 }, { DESTROYER, 3 } } }, ShipNum=6, Fuel=70, Ammunition=70, Steel=50},
+            new ExpeditionInfo {Area="北方", EName="航空機輸送作戦", Time="05:00", Lv=15, RequireShipType=new[] { new Dictionary<string, int> { { AIRCRAFTCARRIER, 1 }, { DESTROYER, 3 } } }, ShipNum=6, Steel=300, Bauxite=100, InstantRepairMaterials=1},
+            new ExpeditionInfo {Area="北方", EName="北号作戦", Time="06:00", Lv=20, RequireShipType=new[] { new Dictionary<string, int> { { AVIATIONBATTLESHIP, 2 }, { DESTROYER, 2 } } }, ShipNum=6, Fuel=400, Steel=50, Bauxite=30, DevelopmentMaterials=1, FurnitureBox="小1"},
+            new ExpeditionInfo {Area="北方", EName="潜水艦哨戒任務",  Time="02:00", RequireShipType=new[] { new Dictionary<string, int> { { SUBMARINE, 1 }, { LIGHTCRUISER, 1 } } }, Lv=1, ShipNum=2, Steel=150, DevelopmentMaterials=1, FurnitureBox="小1"},
+            new ExpeditionInfo {Area="北方", EName="北方鼠輸送作戦", Time="02:20", Lv=15, SumLv=30, RequireItemNum=new Dictionary<string, int> { { DRUMCANISTER, 3 } }, RequireItemShipNum=new Dictionary<string, int>() { { DRUMCANISTER, 3 } }, RequireShipType=new[] { new Dictionary<string, int> { { LIGHTCRUISER, 1 }, {DESTROYER, 4 } } }, ShipNum=5, Fuel=320, Ammunition=270, FurnitureBox="小1"},
+            new ExpeditionInfo {Area="北方", EName="艦隊演習", Time="03:00", Lv=30, SumLv=45, RequireShipType=new[] { new Dictionary<string, int> { { HEAVYCRUISER, 1 }, { LIGHTCRUISER, 1 } , {DESTROYER, 2 } } }, ShipNum=6, Ammunition=10},
+            new ExpeditionInfo {Area="北方", EName="航空戦艦運用演習", Time="04:00", Lv=50, SumLv=200, RequireShipType=new[] { new Dictionary<string, int> { { AVIATIONBATTLESHIP, 2 }, {DESTROYER, 2 } } }, ShipNum=6, Ammunition=20, Bauxite=100},
+            new ExpeditionInfo {Area="北方", EName="北方航路海上護衛", Time="08:20", Lv=50, SumLv=200, RequireShipType=new[] { new Dictionary<string, int> { { LIGHTCRUISER, 1 }, {DESTROYER, 4 } }}, ShipNum=6, Fuel=500, Bauxite=150, InstantRepairMaterials=1, DevelopmentMaterials=2, FlagShipType = LIGHTCRUISER},
 
-            new ExpeditionInfo {Area="西方", EName="通商破壊作戦", Time="40:00", Lv=25, RequireShipType=new Dictionary<string, int>() { { HEAVYCRUISER, 2 }, {DESTROYER, 2 } }, ShipNum=4, Fuel=900, Steel=500, },
-            new ExpeditionInfo {Area="西方", EName="敵母港空襲作戦", Time="80:00", Lv=30, RequireShipType=new Dictionary<string, int>() { { AIRCRAFTCARRIER, 1 },  { LIGHTCRUISER, 1 }, {DESTROYER, 2 } }, ShipNum=4, Bauxite=900, InstantRepairMaterials=3},
-            new ExpeditionInfo {Area="西方", EName="潜水艦通商破壊作戦", Time="20:00", Lv=1, RequireShipType=new Dictionary<string, int>() { { SUBMARINE, 2 } }, ShipNum=2, Steel=800, DevelopmentMaterials=1, FurnitureBox="小2"},
-            new ExpeditionInfo {Area="西方", EName="西方海域封鎖作戦", Time="25:00", Lv=30, RequireShipType=new Dictionary<string, int>() { { SUBMARINE, 3 } }, ShipNum=3, Steel=900, Bauxite=350, DevelopmentMaterials=2, FurnitureBox="中2"},
-            new ExpeditionInfo {Area="西方", EName="潜水艦派遣演習", Time="24:00", Lv=50, RequireShipType=new Dictionary<string, int>() { { SUBMARINE, 3 } }, ShipNum=3, Bauxite=100, DevelopmentMaterials=1, FurnitureBox="小1"},
-            new ExpeditionInfo {Area="西方", EName="潜水艦派遣作戦", Time="48:00", Lv=55, RequireShipType=new Dictionary<string, int>() { { SUBMARINE, 4 } }, ShipNum=4, Bauxite=100, DevelopmentMaterials=3},
-            new ExpeditionInfo {Area="西方", EName="海外艦との接触", Time="02:00", Lv=60,  SumLv=200, RequireShipType=new Dictionary<string, int>() { { SUBMARINE, 4 } }, ShipNum=4, Ammunition=30, FurnitureBox="小1"},
-            new ExpeditionInfo {Area="西方", EName="遠洋練習航海", Time="24:00", Lv=5, RequireShipType=new Dictionary<string, int>() { { TRAININGCRUISER, 1 }, {DESTROYER, 2 } }, ShipNum=3, Fuel=50, Ammunition=50, Steel=50, Bauxite=50, FurnitureBox="大1", FlagShipType = TRAININGCRUISER},
+            new ExpeditionInfo {Area="西方", EName="通商破壊作戦", Time="40:00", Lv=25, RequireShipType=new[] { new Dictionary<string, int> { { HEAVYCRUISER, 2 }, {DESTROYER, 2 } } }, ShipNum=4, Fuel=900, Steel=500, },
+            new ExpeditionInfo {Area="西方", EName="敵母港空襲作戦", Time="80:00", Lv=30, RequireShipType=new[] { new Dictionary<string, int> { { AIRCRAFTCARRIER, 1 },  { LIGHTCRUISER, 1 } , {DESTROYER, 2 } } }, ShipNum=4, Bauxite=900, InstantRepairMaterials=3},
+            new ExpeditionInfo {Area="西方", EName="潜水艦通商破壊作戦", Time="20:00", Lv=1, RequireShipType=new[] { new Dictionary<string, int> { { SUBMARINE, 2 } } }, ShipNum=2, Steel=800, DevelopmentMaterials=1, FurnitureBox="小2"},
+            new ExpeditionInfo {Area="西方", EName="西方海域封鎖作戦", Time="25:00", Lv=30, RequireShipType=new[] { new Dictionary<string, int> { { SUBMARINE, 3 } } }, ShipNum=3, Steel=900, Bauxite=350, DevelopmentMaterials=2, FurnitureBox="中2"},
+            new ExpeditionInfo {Area="西方", EName="潜水艦派遣演習", Time="24:00", Lv=50, RequireShipType=new[] { new Dictionary<string, int> { { SUBMARINE, 3 } } }, ShipNum=3, Bauxite=100, DevelopmentMaterials=1, FurnitureBox="小1"},
+            new ExpeditionInfo {Area="西方", EName="潜水艦派遣作戦", Time="48:00", Lv=55, RequireShipType=new[] { new Dictionary<string, int> { { SUBMARINE, 4 } } }, ShipNum=4, Bauxite=100, DevelopmentMaterials=3},
+            new ExpeditionInfo {Area="西方", EName="海外艦との接触", Time="02:00", Lv=60,  SumLv=200, RequireShipType=new[]{ new Dictionary<string, int>() { { SUBMARINE, 4 } } }, ShipNum=4, Ammunition=30, FurnitureBox="小1"},
+            new ExpeditionInfo {Area="西方", EName="遠洋練習航海", Time="24:00", Lv=5, RequireShipType=new[] { new Dictionary<string, int> { { TRAININGCRUISER, 1 }, { DESTROYER, 2 } } }, ShipNum=3, Fuel=50, Ammunition=50, Steel=50, Bauxite=50, FurnitureBox="大1", FlagShipType = TRAININGCRUISER},
 
-            new ExpeditionInfo {Area="南方", EName="MO作戦", Time="07:00", Lv=40, RequireShipType=new Dictionary<string, int>() { { AIRCRAFTCARRIER, 2 }, { HEAVYCRUISER, 1 }, {DESTROYER, 1 } }, ShipNum=6, Fuel=0, Ammunition=0, Steel=240, Bauxite=280, DevelopmentMaterials=1, FurnitureBox="小2"},
-            new ExpeditionInfo {Area="南方", EName="水上機基地建設", Time="09:00", Lv=30, RequireShipType=new Dictionary<string, int>() { { SEAPLANETENDER, 2 }, { LIGHTCRUISER, 1 }, {DESTROYER, 1 } }, ShipNum=6, Fuel=480, Ammunition=0, Steel=200, Bauxite=200, InstantRepairMaterials=1, FurnitureBox="中1"},
-            new ExpeditionInfo {Area="南方", EName="東京急行", Time="02:45", Lv=50, SumLv=200, RequireItemNum=new Dictionary<string, int>() { { DRUMCANISTER, 4 } }, RequireItemShipNum=new Dictionary<string, int>() { { DRUMCANISTER, 3 } }, RequireShipType=new Dictionary<string, int>() { { LIGHTCRUISER, 1 }, {DESTROYER, 5 } }, ShipNum=6, Fuel=0, Ammunition=380, Steel=270, Bauxite=0, FurnitureBox="小1"},
-            new ExpeditionInfo {Area="南方", EName="東京急行(弐)", Time="02:55", Lv=65, SumLv=240, RequireItemNum=new Dictionary<string, int>() { { DRUMCANISTER, 8 } }, RequireItemShipNum=new Dictionary<string, int>() { { DRUMCANISTER, 4 } }, RequireShipType=new Dictionary<string, int>() { {DESTROYER, 5 } }, ShipNum=6, Fuel=420, Ammunition=0, Steel=200, Bauxite=0, FurnitureBox="小1"},
-            new ExpeditionInfo {Area="南方", EName="遠洋潜水艦作戦", Time="30:00", Lv=3, SumLv=180, RequireShipType=new Dictionary<string, int>() { { SUBMARINETENDER, 1 }, { SUBMARINE, 4 } }, ShipNum=5, Fuel=0, Ammunition=0, Steel=300, Bauxite=0, InstantRepairMaterials=2, FurnitureBox="中1"},
-            new ExpeditionInfo {Area="南方", EName="水上機前線輸送", Time="06:50", Lv=25, SumLv=150, RequireShipType=new Dictionary<string, int>() { { LIGHTCRUISER, 1 }, { SEAPLANETENDER, 2 }, {DESTROYER, 2 } }, ShipNum=6, Fuel=300, Ammunition=300, Steel=0, Bauxite=100, InstantRepairMaterials=1, FurnitureBox="小3", FlagShipType = LIGHTCRUISER},
+            new ExpeditionInfo {Area="南方", EName="MO作戦", Time="07:00", Lv=40, RequireShipType=new[]{new Dictionary<string, int>() { { AIRCRAFTCARRIER, 2 }, { HEAVYCRUISER, 1 }, {DESTROYER, 1 } } }, ShipNum=6, Fuel=0, Ammunition=0, Steel=240, Bauxite=280, DevelopmentMaterials=1, FurnitureBox="小2"},
+            new ExpeditionInfo {Area="南方", EName="水上機基地建設", Time="09:00", Lv=30, RequireShipType=new[]{ new Dictionary<string, int>() { { SEAPLANETENDER, 2 }, { LIGHTCRUISER, 1 }, { DESTROYER, 1 } } }, ShipNum=6, Fuel=480, Ammunition=0, Steel=200, Bauxite=200, InstantRepairMaterials=1, FurnitureBox="中1"},
+            new ExpeditionInfo {Area="南方", EName="東京急行", Time="02:45", Lv=50, SumLv=200, RequireItemNum=new Dictionary<string, int>() { { DRUMCANISTER, 4 } } , RequireItemShipNum=new Dictionary<string, int>() { { DRUMCANISTER, 3 } }, RequireShipType=new[] { new Dictionary<string, int> { { LIGHTCRUISER, 1 }, { DESTROYER, 5 } } }, ShipNum=6, Fuel=0, Ammunition=380, Steel=270, Bauxite=0, FurnitureBox="小1"},
+            new ExpeditionInfo {Area="南方", EName="東京急行(弐)", Time="02:55", Lv=65, SumLv=240, RequireItemNum=new Dictionary<string, int>() { { DRUMCANISTER, 8 } }, RequireItemShipNum=new Dictionary<string, int>() { { DRUMCANISTER, 4 } }, RequireShipType=new[] { new Dictionary<string, int> { {DESTROYER, 5 } } }, ShipNum=6, Fuel=420, Ammunition=0, Steel=200, Bauxite=0, FurnitureBox="小1"},
+            new ExpeditionInfo {Area="南方", EName="遠洋潜水艦作戦", Time="30:00", Lv=3, SumLv=180, RequireShipType=new[] { new Dictionary<string, int> { { SUBMARINETENDER, 1 }, { SUBMARINE, 4 } } }, ShipNum=5, Fuel=0, Ammunition=0, Steel=300, Bauxite=0, InstantRepairMaterials=2, FurnitureBox="中1"},
+            new ExpeditionInfo {Area="南方", EName="水上機前線輸送", Time="06:50", Lv=25, SumLv=150, RequireShipType=new[] { new Dictionary<string, int> { { LIGHTCRUISER, 1 }, { SEAPLANETENDER, 2 }, {DESTROYER, 2 } } }, ShipNum=6, Fuel=300, Ammunition=300, Steel=0, Bauxite=100, InstantRepairMaterials=1, FurnitureBox="小3", FlagShipType = LIGHTCRUISER},
         };
 
         public void Check()
@@ -285,20 +312,21 @@ namespace ExpeditionListPlugin
         {
             if (null == RequireShipType) return true;
 
-            foreach (KeyValuePair<string, int> pair in RequireShipType)
+            foreach (var rst in RequireShipType)
             {
-                Regex re = new Regex(pair.Key);
-                if (KanColleClient.Current.Homeport.Organization.Fleets[index].Ships
-                    .Where(fleet => re.Match(fleet.Info.ShipType.Name).Success).Count() < pair.Value)
-                    return false;
+                if (rst.All(typ => KanColleClient.Current.Homeport.Organization.Fleets[index].Ships
+                     .Where(fleet => new Regex(typ.Key).Match(fleet.Info.ShipType.Name).Success).Count() >= typ.Value) == true)
+                {
+                    return true;
+                }
             }
 
-            return true;
+            return false;
         }
 
         /// <summary>
         /// 装備のチェック
-        /// </summary>
+        /// </summary{
         /// <param name="index">The index.</param>
         /// <returns></returns>
         private bool RequireItemCheck(int index)
@@ -391,7 +419,7 @@ namespace ExpeditionListPlugin
         private bool SumASWCheck(int index)
         {
             if (null == SumASW) return true;
-            
+
             var not_types = new SlotItemType[] { SlotItemType.水上偵察機, SlotItemType.水上爆撃機, SlotItemType.大型飛行艇 };
 
             //水偵・水爆・飛行艇の対潜値の合計を取得

--- a/ExpeditionListPlugin/ExpeditionInfo.cs
+++ b/ExpeditionListPlugin/ExpeditionInfo.cs
@@ -1,4 +1,5 @@
 ﻿using Grabacr07.KanColleWrapper;
+using Grabacr07.KanColleWrapper.Models;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -141,12 +142,11 @@ namespace ExpeditionListPlugin
         /// 合計対潜値
         /// </summary>
         public int? SumASW { get; set; }
-        //
+        
         /// <summary>
         /// 合計索敵値
         /// </summary>
         public int? SumViewRange { get; set; }
-
 
         public int? Fuel { get; set; }
         public int? Ammunition { get; set; }
@@ -155,10 +155,12 @@ namespace ExpeditionListPlugin
         public int? InstantBuildMaterials { get; set; }
         public int? InstantRepairMaterials { get; set; }
         public int? DevelopmentMaterials { get; set; }
+        
         /// <summary>
         /// 家具箱
         /// </summary>
         public string FurnitureBox { get; set; }
+
         public bool isFuelNull { get { return Fuel == null; } }
         public bool isAmmunitionNull { get { return Ammunition == null; } }
         public bool isSteelNull { get { return Steel == null; } }
@@ -389,8 +391,19 @@ namespace ExpeditionListPlugin
         private bool SumASWCheck(int index)
         {
             if (null == SumASW) return true;
-            //南西方面航空偵察作戦の 但し水偵・水爆・飛行艇の対潜値は無効 はまだチェックしない
-            return KanColleClient.Current.Homeport.Organization.Fleets[index].Ships.Select(s => s.ASW).Sum() >= SumASW;
+            
+            var not_types = new SlotItemType[] { SlotItemType.水上偵察機, SlotItemType.水上爆撃機, SlotItemType.大型飛行艇 };
+
+            //水偵・水爆・飛行艇の対潜値の合計を取得
+            var not_sum_asw = KanColleClient.Current.Homeport.Organization.Fleets[index].Ships.Select(
+                ship => ship.EquippedItems.Where(item => not_types.Any(t => t == item.Item.Info.Type)   //水偵・水爆・飛行艇の絞込み
+                    ).Sum(s => s.Item.Info.ASW)).Sum(); //対潜値の合計
+
+            //すべての装備込み対潜値の合計を取得
+            var sum_asw = KanColleClient.Current.Homeport.Organization.Fleets[index].Ships.Select(s => s.ASW).Sum();
+
+            //水偵・水爆・飛行艇の対潜値を無効にする
+            return sum_asw - not_sum_asw >= SumASW;
         }
 
         /// <summary>

--- a/ExpeditionListPlugin/ExpeditionListPlugin.csproj
+++ b/ExpeditionListPlugin/ExpeditionListPlugin.csproj
@@ -53,21 +53,18 @@
       <HintPath>..\packages\LivetCask.1.3.1.0\lib\net45\Livet.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="log4net, Version=2.0.6.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\packages\log4net.2.0.6\lib\net45-full\log4net.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="MetroRadiance, Version=2.3.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MetroRadiance.2.3.0\lib\net46\MetroRadiance.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="MetroRadiance, Version=2.4.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MetroRadiance.2.4.0\lib\net46\MetroRadiance.dll</HintPath>
     </Reference>
     <Reference Include="MetroRadiance.Chrome, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MetroRadiance.Chrome.2.2.0\lib\net46\MetroRadiance.Chrome.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="MetroRadiance.Core, Version=2.2.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MetroRadiance.Core.2.2.1\lib\net46\MetroRadiance.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="MetroRadiance.Core, Version=2.4.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MetroRadiance.Core.2.4.0\lib\net46\MetroRadiance.Core.dll</HintPath>
     </Reference>
     <Reference Include="MetroTrilithon, Version=0.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MetroTrilithon.0.2.0\lib\portable-net45+win+wp80+MonoAndroid10+xamarinios10+MonoTouch10\MetroTrilithon.dll</HintPath>
@@ -78,9 +75,8 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Expression.Interactions, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
-    <Reference Include="Nekoxy, Version=1.5.2.20, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Nekoxy.1.5.2.20\lib\net45\Nekoxy.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Nekoxy, Version=1.5.3.21, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nekoxy.1.5.3.21\lib\net45\Nekoxy.dll</HintPath>
     </Reference>
     <Reference Include="StatefulModel, Version=0.5.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\StatefulModel.0.6.0\lib\portable-net45+win+wp80+MonoAndroid10+xamarinios10+MonoTouch10\StatefulModel.dll</HintPath>
@@ -150,8 +146,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Reflection.TypeExtensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Reflection.TypeExtensions.4.3.0\lib\net46\System.Reflection.TypeExtensions.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\System.Reflection.TypeExtensions.4.4.0\lib\net46\System.Reflection.TypeExtensions.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
@@ -189,8 +184,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="TrotiNet, Version=0.8.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Nekoxy.1.5.2.20\lib\net45\TrotiNet.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Nekoxy.1.5.3.21\lib\net45\TrotiNet.dll</HintPath>
     </Reference>
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />

--- a/ExpeditionListPlugin/app.config
+++ b/ExpeditionListPlugin/app.config
@@ -8,7 +8,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.6.0" newVersion="2.0.6.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.8.0" newVersion="2.0.8.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/ExpeditionListPlugin/packages.config
+++ b/ExpeditionListPlugin/packages.config
@@ -1,21 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ElementalAnnotations-Core" version="1.0.1" targetFramework="net46" />
-  <package id="ElementalAnnotations-Dark" version="1.0.1" targetFramework="net46" />
-  <package id="ElementalAnnotations-Dualism" version="1.0.1" targetFramework="net46" />
-  <package id="ElementalAnnotations-Light" version="1.0.1" targetFramework="net46" />
+  <package id="ElementalAnnotations-Dark" version="1.0.2" targetFramework="net46" />
+  <package id="ElementalAnnotations-Dualism" version="1.0.2" targetFramework="net46" />
+  <package id="ElementalAnnotations-Light" version="1.0.2" targetFramework="net46" />
   <package id="KanColleViewer.Composition" version="1.4.0" targetFramework="net46" />
   <package id="KanColleViewer.Controls" version="1.3.2" targetFramework="net46" />
   <package id="KanColleViewer.PluginAnalyzer" version="1.1.1.0" targetFramework="net46" />
   <package id="KanColleWrapper" version="1.6.2" targetFramework="net46" />
   <package id="LivetCask" version="1.3.1.0" targetFramework="net452" />
-  <package id="log4net" version="2.0.6" targetFramework="net46" />
-  <package id="MetroRadiance" version="2.3.0" targetFramework="net46" />
+  <package id="log4net" version="2.0.8" targetFramework="net46" />
+  <package id="MetroRadiance" version="2.4.0" targetFramework="net46" />
   <package id="MetroRadiance.Chrome" version="2.2.0" targetFramework="net46" />
-  <package id="MetroRadiance.Core" version="2.2.1" targetFramework="net46" />
+  <package id="MetroRadiance.Core" version="2.4.0" targetFramework="net46" />
   <package id="MetroTrilithon" version="0.2.0" targetFramework="net46" />
   <package id="MetroTrilithon.Desktop" version="0.2.3" targetFramework="net46" />
-  <package id="Nekoxy" version="1.5.2.20" targetFramework="net46" />
+  <package id="Nekoxy" version="1.5.3.21" targetFramework="net46" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net452" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net452" />
   <package id="Rx-Linq" version="2.2.5" targetFramework="net452" />
@@ -38,7 +38,7 @@
   <package id="System.Net.Sockets" version="4.3.0" targetFramework="net46" />
   <package id="System.Reflection" version="4.3.0" targetFramework="net46" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net46" />
-  <package id="System.Reflection.TypeExtensions" version="4.3.0" targetFramework="net46" />
+  <package id="System.Reflection.TypeExtensions" version="4.4.0" targetFramework="net46" />
   <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net46" />
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net46" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net46" />

--- a/ExpeditionListPluginTests/ChainingAssertion.MSTest.cs
+++ b/ExpeditionListPluginTests/ChainingAssertion.MSTest.cs
@@ -1,0 +1,1215 @@
+﻿/*--------------------------------------------------------------------------
+ * Chaining Assertion
+ * ver 1.7.1.0 (Apr. 29th, 2013)
+ *
+ * created and maintained by neuecc <ils@neue.cc - @neuecc on Twitter>
+ * licensed under Microsoft Public License(Ms-PL)
+ * http://chainingassertion.codeplex.com/
+ *--------------------------------------------------------------------------*/
+
+/* -- Tutorial --
+ * | at first, include this file on MSTest Project.
+ * 
+ * | three example, "Is" overloads.
+ * 
+ * // This same as Assert.AreEqual(25, Math.Pow(5, 2))
+ * Math.Pow(5, 2).Is(25);
+ * 
+ * // This same as Assert.IsTrue("foobar".StartsWith("foo") && "foobar".EndWith("bar"))
+ * "foobar".Is(s => s.StartsWith("foo") && s.EndsWith("bar"));
+ * 
+ * // This same as CollectionAssert.AreEqual(Enumerable.Range(1,5), new[]{1, 2, 3, 4, 5})
+ * Enumerable.Range(1, 5).Is(1, 2, 3, 4, 5);
+ * 
+ * | CollectionAssert
+ * | if you want to use CollectionAssert Methods then use Linq to Objects and Is
+ * 
+ * var array = new[] { 1, 3, 7, 8 };
+ * array.Count().Is(4);
+ * array.Contains(8).IsTrue(); // IsTrue() == Is(true)
+ * array.All(i => i < 5).IsFalse(); // IsFalse() == Is(false)
+ * array.Any().Is(true);
+ * new int[] { }.Any().Is(false);   // IsEmpty
+ * array.OrderBy(x => x).Is(array); // IsOrdered
+ *
+ * | Other Assertions
+ * 
+ * // Null Assertions
+ * Object obj = null;
+ * obj.IsNull();             // Assert.IsNull(obj)
+ * new Object().IsNotNull(); // Assert.IsNotNull(obj)
+ *
+ * // Not Assertion
+ * "foobar".IsNot("fooooooo"); // Assert.AreNotEqual
+ * new[] { "a", "z", "x" }.IsNot("a", "x", "z"); /// CollectionAssert.AreNotEqual
+ *
+ * // ReferenceEqual Assertion
+ * var tuple = Tuple.Create("foo");
+ * tuple.IsSameReferenceAs(tuple); // Assert.AreSame
+ * tuple.IsNotSameReferenceAs(Tuple.Create("foo")); // Assert.AreNotSame
+ *
+ * // Type Assertion
+ * "foobar".IsInstanceOf<string>(); // Assert.IsInstanceOfType
+ * (999).IsNotInstanceOf<double>(); // Assert.IsNotInstanceOfType
+ * 
+ * | Advanced Collection Assertion
+ * 
+ * var lower = new[] { "a", "b", "c" };
+ * var upper = new[] { "A", "B", "C" };
+ *
+ * // Comparer CollectionAssert, use IEqualityComparer<T> or Func<T,T,bool> delegate
+ * lower.Is(upper, StringComparer.InvariantCultureIgnoreCase);
+ * lower.Is(upper, (x, y) => x.ToUpper() == y.ToUpper());
+ *
+ * // or you can use Linq to Objects - SequenceEqual
+ * lower.SequenceEqual(upper, StringComparer.InvariantCultureIgnoreCase).Is(true);
+ * 
+ * | StructuralEqual
+ * 
+ * class MyClass
+ * {
+ *     public int IntProp { get; set; }
+ *     public string StrField;
+ * }
+ * 
+ * var mc1 = new MyClass() { IntProp = 10, StrField = "foo" };
+ * var mc2 = new MyClass() { IntProp = 10, StrField = "foo" };
+ * 
+ * mc1.IsStructuralEqual(mc2); // deep recursive value equality compare
+ * 
+ * mc1.IntProp = 20;
+ * mc1.IsNotStructuralEqual(mc2);
+ * 
+ * | DynamicAccessor
+ * 
+ * // AsDynamic convert to "dynamic" that can call private method/property/field/indexer.
+ * 
+ * // a class and private field/property/method.
+ * public class PrivateMock
+ * {
+ *     private string privateField = "homu";
+ * 
+ *     private string PrivateProperty
+ *     {
+ *         get { return privateField + privateField; }
+ *         set { privateField = value; }
+ *     }
+ * 
+ *     private string PrivateMethod(int count)
+ *     {
+ *         return string.Join("", Enumerable.Repeat(privateField, count));
+ *     }
+ * }
+ * 
+ * // call private property.
+ * var actual = new PrivateMock().AsDynamic().PrivateProperty;
+ * Assert.AreEqual("homuhomu", actual);
+ * 
+ * // dynamic can't invoke extension methods.
+ * // if you want to invoke "Is" then cast type.
+ * (new PrivateMock().AsDynamic().PrivateMethod(3) as string).Is("homuhomuhomu");
+ * 
+ * // set value
+ * var mock = new PrivateMock().AsDynamic();
+ * mock.PrivateProperty = "mogumogu";
+ * (mock.privateField as string).Is("mogumogu");
+ * 
+ * | Exception Test
+ * 
+ * // Exception Test(alternative of ExpectedExceptionAttribute)
+ * // AssertEx.Throws does not allow derived type
+ * // AssertEx.Catch allows derived type
+ * // AssertEx.ThrowsContractException catch only Code Contract's ContractException
+ * AssertEx.Throws<ArgumentNullException>(() => "foo".StartsWith(null));
+ * AssertEx.Catch<Exception>(() => "foo".StartsWith(null));
+ * AssertEx.ThrowsContractException(() => // contract method //);
+ * 
+ * // return value is occured exception
+ * var ex = AssertEx.Throws<InvalidOperationException>(() =>
+ * {
+ *     throw new InvalidOperationException("foobar operation");
+ * });
+ * ex.Message.Is(s => s.Contains("foobar")); // additional exception assertion
+ * 
+ * // must not throw any exceptions
+ * AssertEx.DoesNotThrow(() =>
+ * {
+ *     // code
+ * });
+ * 
+ * | Parameterized Test
+ * | TestCase takes parameters and send to TestContext's Extension Method "Run".
+ * 
+ * [TestClass]
+ * public class UnitTest
+ * {
+ *     public TestContext TestContext { get; set; }
+ * 
+ *     [TestMethod]
+ *     [TestCase(1, 2, 3)]
+ *     [TestCase(10, 20, 30)]
+ *     [TestCase(100, 200, 300)]
+ *     public void TestMethod2()
+ *     {
+ *         TestContext.Run((int x, int y, int z) =>
+ *         {
+ *             (x + y).Is(z);
+ *             (x + y + z).Is(i => i < 1000);
+ *         });
+ *     }
+ * }
+ * 
+ * | TestCaseSource
+ * | TestCaseSource can take static field/property that types is only object[][].
+ * 
+ * [TestMethod]
+ * [TestCaseSource("toaruSource")]
+ * public void TestTestCaseSource()
+ * {
+ *     TestContext.Run((int x, int y, string z) =>
+ *     {
+ *         string.Concat(x, y).Is(z);
+ *     });
+ * }
+ * 
+ * public static object[] toaruSource = new[]
+ * {
+ *     new object[] {1, 1, "11"},
+ *     new object[] {5, 3, "53"},
+ *     new object[] {9, 4, "94"}
+ * };
+ * 
+ * -- more details see project home --*/
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Dynamic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Microsoft.VisualStudio.TestTools.UnitTesting
+{
+    #region Extensions
+
+    [System.Diagnostics.DebuggerStepThroughAttribute]
+    [ContractVerification(false)]
+    public static partial class AssertEx
+    {
+        /// <summary>Assert.AreEqual, if T is IEnumerable then CollectionAssert.AreEqual</summary>
+        public static void Is<T>(this T actual, T expected, string message = "")
+        {
+            if (typeof(T) != typeof(String) && typeof(IEnumerable).IsAssignableFrom(typeof(T)))
+            {
+                ((IEnumerable)actual).Cast<object>().Is(((IEnumerable)expected).Cast<object>(), message);
+                return;
+            }
+
+            Assert.AreEqual(expected, actual, message);
+        }
+
+        /// <summary>Assert.IsTrue(predicate(value))</summary>
+        public static void Is<T>(this T value, Expression<Func<T, bool>> predicate, string message = "")
+        {
+            var condition = predicate.Compile().Invoke(value);
+
+            var paramName = predicate.Parameters.First().Name;
+            string msg = "";
+            try
+            {
+                var dumper = new ExpressionDumper<T>(value, predicate.Parameters.Single());
+                dumper.Visit(predicate);
+                var dump = string.Join(", ", dumper.Members.Select(kvp => kvp.Key + " = " + kvp.Value));
+                msg = string.Format("\r\n{0} = {1}\r\n{2}\r\n{3}{4}",
+                    paramName, value, dump, predicate,
+                    string.IsNullOrEmpty(message) ? "" : ", " + message);
+            }
+            catch
+            {
+                msg = string.Format("{0} = {1}, {2}{3}",
+                    paramName, value, predicate,
+                    string.IsNullOrEmpty(message) ? "" : ", " + message);
+            }
+
+            Assert.IsTrue(condition, msg);
+        }
+
+        /// <summary>CollectionAssert.AreEqual</summary>
+        public static void Is<T>(this IEnumerable<T> actual, params T[] expected)
+        {
+            Is(actual, expected.AsEnumerable());
+        }
+
+        /// <summary>CollectionAssert.AreEqual</summary>
+        public static void Is<T>(this IEnumerable<T> actual, IEnumerable<T> expected, string message = "")
+        {
+            CollectionAssert.AreEqual(expected.ToArray(), actual.ToArray(), message);
+        }
+
+        /// <summary>CollectionAssert.AreEqual</summary>
+        public static void Is<T>(this IEnumerable<T> actual, IEnumerable<T> expected, IEqualityComparer<T> comparer, string message = "")
+        {
+            Is(actual, expected, comparer.Equals, message);
+        }
+
+        /// <summary>CollectionAssert.AreEqual</summary>
+        public static void Is<T>(this IEnumerable<T> actual, IEnumerable<T> expected, Func<T, T, bool> equalityComparison, string message = "")
+        {
+            CollectionAssert.AreEqual(expected.ToArray(), actual.ToArray(), new ComparisonComparer<T>(equalityComparison), message);
+        }
+
+        /// <summary>Assert.AreNotEqual, if T is IEnumerable then CollectionAssert.AreNotEqual</summary>
+        public static void IsNot<T>(this T actual, T notExpected, string message = "")
+        {
+            if (typeof(T) != typeof(String) && typeof(IEnumerable).IsAssignableFrom(typeof(T)))
+            {
+                ((IEnumerable)actual).Cast<object>().IsNot(((IEnumerable)notExpected).Cast<object>(), message);
+                return;
+            }
+
+            Assert.AreNotEqual(notExpected, actual, message);
+        }
+
+        /// <summary>CollectionAssert.AreNotEqual</summary>
+        public static void IsNot<T>(this IEnumerable<T> actual, params T[] notExpected)
+        {
+            IsNot(actual, notExpected.AsEnumerable());
+        }
+
+        /// <summary>CollectionAssert.AreNotEqual</summary>
+        public static void IsNot<T>(this IEnumerable<T> actual, IEnumerable<T> notExpected, string message = "")
+        {
+            CollectionAssert.AreNotEqual(notExpected.ToArray(), actual.ToArray(), message);
+        }
+
+        /// <summary>CollectionAssert.AreNotEqual</summary>
+        public static void IsNot<T>(this IEnumerable<T> actual, IEnumerable<T> notExpected, IEqualityComparer<T> comparer, string message = "")
+        {
+            IsNot(actual, notExpected, comparer.Equals, message);
+        }
+
+        /// <summary>CollectionAssert.AreNotEqual</summary>
+        public static void IsNot<T>(this IEnumerable<T> actual, IEnumerable<T> notExpected, Func<T, T, bool> equalityComparison, string message = "")
+        {
+            CollectionAssert.AreNotEqual(notExpected.ToArray(), actual.ToArray(), new ComparisonComparer<T>(equalityComparison), message);
+        }
+
+        /// <summary>Assert.IsNull</summary>
+        public static void IsNull<T>(this T value, string message = "")
+        {
+            Assert.IsNull(value, message);
+        }
+
+        /// <summary>Assert.IsNotNull</summary>
+        public static void IsNotNull<T>(this T value, string message = "")
+        {
+            Assert.IsNotNull(value, message);
+        }
+
+        /// <summary>Is(true)</summary>
+        public static void IsTrue(this bool value, string message = "")
+        {
+            value.Is(true, message);
+        }
+
+        /// <summary>Is(false)</summary>
+        public static void IsFalse(this bool value, string message = "")
+        {
+            value.Is(false, message);
+        }
+
+        /// <summary>Assert.AreSame</summary>
+        public static void IsSameReferenceAs<T>(this T actual, T expected, string message = "")
+        {
+            Assert.AreSame(expected, actual, message);
+        }
+
+        /// <summary>Assert.AreNotSame</summary>
+        public static void IsNotSameReferenceAs<T>(this T actual, T notExpected, string message = "")
+        {
+            Assert.AreNotSame(notExpected, actual, message);
+        }
+
+        /// <summary>Assert.IsInstanceOfType</summary>
+        public static TExpected IsInstanceOf<TExpected>(this object value, string message = "")
+        {
+            Assert.IsInstanceOfType(value, typeof(TExpected), message);
+            return (TExpected)value;
+        }
+
+        /// <summary>Assert.IsNotInstanceOfType</summary>
+        public static void IsNotInstanceOf<TWrong>(this object value, string message = "")
+        {
+            Assert.IsNotInstanceOfType(value, typeof(TWrong), message);
+        }
+
+        /// <summary>Alternative of ExpectedExceptionAttribute(allow derived type)</summary>
+        public static T Catch<T>(Action testCode, string message = "") where T : Exception
+        {
+            var exception = ExecuteCode(testCode);
+            var headerMsg = "Failed Throws<" + typeof(T).Name + ">.";
+            var additionalMsg = string.IsNullOrEmpty(message) ? "" : ", " + message;
+
+            if (exception == null)
+            {
+                var formatted = headerMsg + " No exception was thrown" + additionalMsg;
+                throw new AssertFailedException(formatted);
+            }
+            else if (!typeof(T).IsInstanceOfType(exception))
+            {
+                var formatted = string.Format("{0} Catched:{1}{2}", headerMsg, exception.GetType().Name, additionalMsg);
+                throw new AssertFailedException(formatted);
+            }
+
+            return (T)exception;
+        }
+
+        /// <summary>Alternative of ExpectedExceptionAttribute(not allow derived type)</summary>
+        public static T Throws<T>(Action testCode, string message = "") where T : Exception
+        {
+            var exception = Catch<T>(testCode, message);
+
+            if (!typeof(T).Equals(exception.GetType()))
+            {
+                var headerMsg = "Failed Throws<" + typeof(T).Name + ">.";
+                var additionalMsg = string.IsNullOrEmpty(message) ? "" : ", " + message;
+                var formatted = string.Format("{0} Catched:{1}{2}", headerMsg, exception.GetType().Name, additionalMsg);
+                throw new AssertFailedException(formatted);
+            }
+
+            return (T)exception;
+        }
+
+        /// <summary>expected testCode throws ContractException</summary>
+        /// <returns>ContractException</returns>
+        public static Exception ThrowsContractException(Action testCode, string message = "")
+        {
+            var exception = AssertEx.Catch<Exception>(testCode, message);
+            var type = exception.GetType();
+            if (type.Namespace == "System.Diagnostics.Contracts" && type.Name == "ContractException")
+            {
+                return exception;
+            }
+
+            var additionalMsg = string.IsNullOrEmpty(message) ? "" : ", " + message;
+            var formatted = string.Format("Throwed Exception is not ContractException. Catched:{0}{1}",
+                exception.GetType().Name, additionalMsg);
+
+            throw new AssertFailedException(formatted);
+        }
+
+        /// <summary>does not throw any exceptions</summary>
+        public static void DoesNotThrow(Action testCode, string message = "")
+        {
+            var exception = ExecuteCode(testCode);
+            if (exception != null)
+            {
+                var formatted = string.Format("Failed DoesNotThrow. Catched:{0}{1}", exception.GetType().Name, string.IsNullOrEmpty(message) ? "" : ", " + message);
+                throw new AssertFailedException(formatted);
+            }
+        }
+
+        /// <summary>execute action and return exception when catched otherwise return null</summary>
+        private static Exception ExecuteCode(Action testCode)
+        {
+            try
+            {
+                testCode();
+                return null;
+            }
+            catch (Exception e)
+            {
+                return e;
+            }
+        }
+
+        /// <summary>EqualityComparison to IComparer Converter for CollectionAssert</summary>
+        private class ComparisonComparer<T> : IComparer
+        {
+            readonly Func<T, T, bool> comparison;
+
+            public ComparisonComparer(Func<T, T, bool> comparison)
+            {
+                this.comparison = comparison;
+            }
+
+            public int Compare(object x, object y)
+            {
+                return (comparison != null)
+                    ? comparison((T)x, (T)y) ? 0 : -1
+                    : object.Equals(x, y) ? 0 : -1;
+            }
+        }
+
+        private class ReflectAccessor<T>
+        {
+            public Func<object> GetValue { get; private set; }
+            public Action<object> SetValue { get; private set; }
+
+            public ReflectAccessor(T target, string name)
+            {
+                var field = typeof(T).GetField(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                if (field != null)
+                {
+                    GetValue = () => field.GetValue(target);
+                    SetValue = value => field.SetValue(target, value);
+                    return;
+                }
+
+                var prop = typeof(T).GetProperty(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                if (prop != null)
+                {
+                    GetValue = () => prop.GetValue(target, null);
+                    SetValue = value => prop.SetValue(target, value, null);
+                    return;
+                }
+
+                throw new ArgumentException(string.Format("\"{0}\" not found : Type <{1}>", name, typeof(T).Name));
+            }
+        }
+
+        #region StructuralEqual
+
+        /// <summary>Assert by deep recursive value equality compare</summary>
+        public static void IsStructuralEqual(this object actual, object expected, string message = "")
+        {
+            message = (string.IsNullOrEmpty(message) ? "" : ", " + message);
+            if (object.ReferenceEquals(actual, expected)) return;
+
+            if (actual == null) throw new AssertFailedException("actual is null" + message);
+            if (expected == null) throw new AssertFailedException("actual is not null" + message);
+            if (actual.GetType() != expected.GetType())
+            {
+                var msg = string.Format("expected type is {0} but actual type is {1}{2}",
+                    expected.GetType().Name, actual.GetType().Name, message);
+                throw new AssertFailedException(msg);
+            }
+
+            var r = StructuralEqual(actual, expected, new[] { actual.GetType().Name }); // root type
+            if (!r.IsEquals)
+            {
+                var msg = string.Format("is not structural equal, failed at {0}, actual = {1} expected = {2}{3}",
+                    string.Join(".", r.Names), r.Left, r.Right, message);
+                throw new AssertFailedException(msg);
+            }
+        }
+
+        /// <summary>Assert by deep recursive value equality compare</summary>
+        public static void IsNotStructuralEqual(this object actual, object expected, string message = "")
+        {
+            message = (string.IsNullOrEmpty(message) ? "" : ", " + message);
+            if (object.ReferenceEquals(actual, expected)) throw new AssertFailedException("actual is same reference" + message); ;
+
+            if (actual == null) return;
+            if (expected == null) return;
+            if (actual.GetType() != expected.GetType())
+            {
+                return;
+            }
+
+            var r = StructuralEqual(actual, expected, new[] { actual.GetType().Name }); // root type
+            if (r.IsEquals)
+            {
+                throw new AssertFailedException("is structural equal" + message);
+            }
+        }
+
+        static EqualInfo SequenceEqual(IEnumerable leftEnumerable, IEnumerable rightEnumarable, IEnumerable<string> names)
+        {
+            var le = leftEnumerable.GetEnumerator();
+            using (le as IDisposable)
+            {
+                var re = rightEnumarable.GetEnumerator();
+
+                using (re as IDisposable)
+                {
+                    var index = 0;
+                    while (true)
+                    {
+                        object lValue = null;
+                        object rValue = null;
+                        var lMove = le.MoveNext();
+                        var rMove = re.MoveNext();
+                        if (lMove) lValue = le.Current;
+                        if (rMove) rValue = re.Current;
+
+                        if (lMove && rMove)
+                        {
+                            var result = StructuralEqual(lValue, rValue, names.Concat(new[] { "[" + index + "]" }));
+                            if (!result.IsEquals)
+                            {
+                                return result;
+                            }
+                        }
+
+                        if ((lMove == true && rMove == false) || (lMove == false && rMove == true))
+                        {
+                            return new EqualInfo { IsEquals = false, Left = lValue, Right = rValue, Names = names.Concat(new[] { "[" + index + "]" }) };
+                        }
+                        if (lMove == false && rMove == false) break;
+                        index++;
+                    }
+                }
+            }
+            return new EqualInfo { IsEquals = true, Left = leftEnumerable, Right = rightEnumarable, Names = names };
+        }
+
+        static EqualInfo StructuralEqual(object left, object right, IEnumerable<string> names)
+        {
+            // type and basic checks
+            if (object.ReferenceEquals(left, right)) return new EqualInfo { IsEquals = true, Left = left, Right = right, Names = names };
+            if (left == null || right == null) return new EqualInfo { IsEquals = false, Left = left, Right = right, Names = names };
+            var lType = left.GetType();
+            var rType = right.GetType();
+            if (lType != rType) return new EqualInfo { IsEquals = false, Left = left, Right = right, Names = names };
+
+            var type = left.GetType();
+
+            // not object(int, string, etc...)
+            if (Type.GetTypeCode(type) != TypeCode.Object)
+            {
+                return new EqualInfo { IsEquals = left.Equals(right), Left = left, Right = right, Names = names };
+            }
+
+            // is sequence
+            if (typeof(IEnumerable).IsAssignableFrom(type))
+            {
+                return SequenceEqual((IEnumerable)left, (IEnumerable)right, names);
+            }
+
+            // IEquatable<T>
+            var equatable = typeof(IEquatable<>).MakeGenericType(type);
+            if (equatable.IsAssignableFrom(type))
+            {
+                var result = (bool)equatable.GetMethod("Equals").Invoke(left, new[] { right });
+                return new EqualInfo { IsEquals = result, Left = left, Right = right, Names = names };
+            }
+
+            // is object
+            var fields = left.GetType().GetFields(BindingFlags.Instance | BindingFlags.Public);
+            var properties = left.GetType().GetProperties(BindingFlags.Instance | BindingFlags.Public).Where(x => x.GetGetMethod(false) != null);
+            var members = fields.Cast<MemberInfo>().Concat(properties);
+
+            foreach (dynamic mi in fields.Cast<MemberInfo>().Concat(properties))
+            {
+                var concatNames = names.Concat(new[] { (string)mi.Name });
+
+                object lv = mi.GetValue(left);
+                object rv = mi.GetValue(right);
+                var result = StructuralEqual(lv, rv, concatNames);
+                if (!result.IsEquals)
+                {
+                    return result;
+                }
+            }
+
+            return new EqualInfo { IsEquals = true, Left = left, Right = right, Names = names };
+        }
+
+        private class EqualInfo
+        {
+            public object Left;
+            public object Right;
+            public bool IsEquals;
+            public IEnumerable<string> Names;
+        }
+
+        #endregion
+
+        #region DynamicAccessor
+
+        /// <summary>to DynamicAccessor that can call private method/field/property/indexer.</summary>
+        public static dynamic AsDynamic<T>(this T target)
+        {
+            return new DynamicAccessor<T>(target);
+        }
+
+        private class DynamicAccessor<T> : DynamicObject
+        {
+            private readonly T target;
+            private static readonly BindingFlags TransparentFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+
+            public DynamicAccessor(T target)
+            {
+                this.target = target;
+            }
+
+            public override bool TrySetIndex(SetIndexBinder binder, object[] indexes, object value)
+            {
+                try
+                {
+                    typeof(T).InvokeMember("Item", TransparentFlags | BindingFlags.SetProperty, null, target, indexes.Concat(new[] { value }).ToArray());
+                    return true;
+                }
+                catch (MissingMethodException) { throw new ArgumentException(string.Format("indexer not found : Type <{0}>", typeof(T).Name)); };
+            }
+
+            public override bool TryGetIndex(GetIndexBinder binder, object[] indexes, out object result)
+            {
+                try
+                {
+                    result = typeof(T).InvokeMember("Item", TransparentFlags | BindingFlags.GetProperty, null, target, indexes);
+                    return true;
+                }
+                catch (MissingMethodException) { throw new ArgumentException(string.Format("indexer not found : Type <{0}>", typeof(T).Name)); };
+            }
+
+            public override bool TrySetMember(SetMemberBinder binder, object value)
+            {
+                var accessor = new ReflectAccessor<T>(target, binder.Name);
+                accessor.SetValue(value);
+                return true;
+            }
+
+            public override bool TryGetMember(GetMemberBinder binder, out object result)
+            {
+                var accessor = new ReflectAccessor<T>(target, binder.Name);
+                result = accessor.GetValue();
+                return true;
+            }
+
+            public override bool TryInvokeMember(InvokeMemberBinder binder, object[] args, out object result)
+            {
+                var csharpBinder = binder.GetType().GetInterface("Microsoft.CSharp.RuntimeBinder.ICSharpInvokeOrInvokeMemberBinder");
+                if (csharpBinder == null) throw new ArgumentException("is not csharp code");
+
+                var typeArgs = (csharpBinder.GetProperty("TypeArguments").GetValue(binder, null) as IList<Type>).ToArray();
+                var parameterTypes = (binder.GetType().GetField("Cache", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(binder) as Dictionary<Type, object>)
+                    .First()
+                    .Key
+                    .GetGenericArguments()
+                    .Skip(2)
+                    .Take(args.Length)
+                    .ToArray();
+
+                var method = MatchMethod(binder.Name, args, typeArgs, parameterTypes);
+                result = method.Invoke(target, args);
+
+                return true;
+            }
+
+            private Type AssignableBoundType(Type left, Type right)
+            {
+                return (left == null || right == null) ? null
+                    : left.IsAssignableFrom(right) ? left
+                    : right.IsAssignableFrom(left) ? right
+                    : null;
+            }
+
+            private MethodInfo MatchMethod(string methodName, object[] args, Type[] typeArgs, Type[] parameterTypes)
+            {
+                // name match
+                var nameMatched = typeof(T).GetMethods(TransparentFlags)
+                    .Where(mi => mi.Name == methodName)
+                    .ToArray();
+                if (!nameMatched.Any()) throw new ArgumentException(string.Format("\"{0}\" not found : Type <{1}>", methodName, typeof(T).Name));
+
+                // type inference
+                var typedMethods = nameMatched
+                    .Select(mi =>
+                    {
+                        var genericArguments = mi.GetGenericArguments();
+
+                        if (!typeArgs.Any() && !genericArguments.Any()) // non generic method
+                        {
+                            return new
+                            {
+                                MethodInfo = mi,
+                                TypeParameters = default(Dictionary<Type, Type>)
+                            };
+                        }
+                        else if (!typeArgs.Any())
+                        {
+                            var parameterGenericTypes = mi.GetParameters()
+                                .Select(pi => pi.ParameterType)
+                                .Zip(parameterTypes, Tuple.Create)
+                                .GroupBy(a => a.Item1, a => a.Item2)
+                                .Where(g => g.Key.IsGenericParameter)
+                                .Select(g => new { g.Key, Type = g.Aggregate(AssignableBoundType) })
+                                .Where(a => a.Type != null);
+
+                            var typeParams = genericArguments
+                                .GroupJoin(parameterGenericTypes, x => x, x => x.Key, (_, Args) => Args)
+                                .ToArray();
+                            if (!typeParams.All(xs => xs.Any())) return null; // types short
+
+                            return new
+                            {
+                                MethodInfo = mi,
+                                TypeParameters = typeParams
+                                    .Select(xs => xs.First())
+                                    .ToDictionary(a => a.Key, a => a.Type)
+                            };
+                        }
+                        else
+                        {
+                            if (genericArguments.Length != typeArgs.Length) return null;
+
+                            return new
+                            {
+                                MethodInfo = mi,
+                                TypeParameters = genericArguments
+                                    .Zip(typeArgs, Tuple.Create)
+                                    .ToDictionary(t => t.Item1, t => t.Item2)
+                            };
+                        }
+                    })
+                    .Where(a => a != null)
+                    .Where(a => a.MethodInfo
+                        .GetParameters()
+                        .Select(pi => pi.ParameterType)
+                        .SequenceEqual(parameterTypes, new EqualsComparer<Type>((x, y) =>
+                            (x.IsGenericParameter)
+                                ? a.TypeParameters[x].IsAssignableFrom(y)
+                                : x.Equals(y)))
+                    )
+                    .ToArray();
+
+                if (!typedMethods.Any()) throw new ArgumentException(string.Format("\"{0}\" not match arguments : Type <{1}>", methodName, typeof(T).Name));
+
+                // nongeneric
+                var nongeneric = typedMethods.Where(a => a.TypeParameters == null).ToArray();
+                if (nongeneric.Length == 1) return nongeneric[0].MethodInfo;
+
+                // generic--
+                var lessGeneric = typedMethods
+                    .Where(a => !a.MethodInfo.GetParameters().All(pi => pi.ParameterType.IsGenericParameter))
+                    .ToArray();
+
+                // generic
+                var generic = (typedMethods.Length == 1)
+                    ? typedMethods[0]
+                    : (lessGeneric.Length == 1 ? lessGeneric[0] : null);
+
+                if (generic != null) return generic.MethodInfo.MakeGenericMethod(generic.TypeParameters.Select(kvp => kvp.Value).ToArray());
+
+                // ambiguous
+                throw new ArgumentException(string.Format("\"{0}\" ambiguous arguments : Type <{1}>", methodName, typeof(T).Name));
+            }
+
+            private class EqualsComparer<TX> : IEqualityComparer<TX>
+            {
+                private readonly Func<TX, TX, bool> equals;
+
+                public EqualsComparer(Func<TX, TX, bool> equals)
+                {
+                    this.equals = equals;
+                }
+
+                public bool Equals(TX x, TX y)
+                {
+                    return equals(x, y);
+                }
+
+                public int GetHashCode(TX obj)
+                {
+                    return 0;
+                }
+            }
+        }
+
+        #endregion
+
+        #region ExpressionDumper
+
+        private class ExpressionDumper<T> : ExpressionVisitor
+        {
+            ParameterExpression param;
+            T target;
+
+            public Dictionary<string, object> Members { get; private set; }
+
+            public ExpressionDumper(T target, ParameterExpression param)
+            {
+                this.target = target;
+                this.param = param;
+                this.Members = new Dictionary<string, object>();
+            }
+
+            protected override System.Linq.Expressions.Expression VisitMember(MemberExpression node)
+            {
+                if (node.Expression == param && !Members.ContainsKey(node.Member.Name))
+                {
+                    var accessor = new ReflectAccessor<T>(target, node.Member.Name);
+                    Members.Add(node.Member.Name, accessor.GetValue());
+                }
+
+                return base.VisitMember(node);
+            }
+        }
+
+        #endregion
+    }
+
+    #endregion
+
+    #region TestCase
+
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    public class TestCaseAttribute : Attribute
+    {
+        public object[] Parameters { get; private set; }
+
+        /// <summary>parameters provide to TestContext.Run.</summary>
+        public TestCaseAttribute(params object[] parameters)
+        {
+            Parameters = parameters;
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    public class TestCaseSourceAttribute : Attribute
+    {
+        public string SourceName { get; private set; }
+
+        /// <summary>point out static field/property name. source must be object[][].</summary>
+        public TestCaseSourceAttribute(string sourceName)
+        {
+            SourceName = sourceName;
+        }
+    }
+
+    public static class TestContextExtensions
+    {
+        private static IEnumerable<object[]> GetParameters(Type classType, string methodName)
+        {
+            var method = classType.GetMethod(methodName);
+
+            var testCase = method
+                .GetCustomAttributes(typeof(TestCaseAttribute), false)
+                .Cast<TestCaseAttribute>()
+                .Select(x => x.Parameters);
+
+            var testCaseSource = method
+                .GetCustomAttributes(typeof(TestCaseSourceAttribute), false)
+                .Cast<TestCaseSourceAttribute>()
+                .SelectMany(x =>
+                {
+                    var p = classType.GetProperty(x.SourceName, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+                    var val = (p != null)
+                        ? p.GetValue(null, null)
+                        : classType.GetField(x.SourceName, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic).GetValue(null);
+
+                    return ((object[])val).Cast<object[]>();
+                });
+
+            return testCase.Concat(testCaseSource);
+        }
+
+        /// <summary>Run Parameterized Test marked by TestCase Attribute.</summary>
+        public static void Run<T1>(this TestContext context, Action<T1> assertion)
+        {
+            var type = Assembly.GetCallingAssembly().GetType(context.FullyQualifiedTestClassName);
+            foreach (var parameters in GetParameters(type, context.TestName))
+            {
+                assertion(
+                    (T1)parameters[0]
+                    );
+            }
+        }
+
+        /// <summary>Run Parameterized Test marked by TestCase Attribute.</summary>
+        public static void Run<T1, T2>(this TestContext context, Action<T1, T2> assertion)
+        {
+            var type = Assembly.GetCallingAssembly().GetType(context.FullyQualifiedTestClassName);
+            foreach (var parameters in GetParameters(type, context.TestName))
+            {
+                assertion(
+                    (T1)parameters[0],
+                    (T2)parameters[1]
+                    );
+            }
+        }
+
+        /// <summary>Run Parameterized Test marked by TestCase Attribute.</summary>
+        public static void Run<T1, T2, T3>(this TestContext context, Action<T1, T2, T3> assertion)
+        {
+            var type = Assembly.GetCallingAssembly().GetType(context.FullyQualifiedTestClassName);
+            foreach (var parameters in GetParameters(type, context.TestName))
+            {
+                assertion(
+                    (T1)parameters[0],
+                    (T2)parameters[1],
+                    (T3)parameters[2]
+                    );
+            }
+        }
+
+        /// <summary>Run Parameterized Test marked by TestCase Attribute.</summary>
+        public static void Run<T1, T2, T3, T4>(this TestContext context, Action<T1, T2, T3, T4> assertion)
+        {
+            var type = Assembly.GetCallingAssembly().GetType(context.FullyQualifiedTestClassName);
+            foreach (var parameters in GetParameters(type, context.TestName))
+            {
+                assertion(
+                    (T1)parameters[0],
+                    (T2)parameters[1],
+                    (T3)parameters[2],
+                    (T4)parameters[3]
+                    );
+            }
+        }
+
+        /// <summary>Run Parameterized Test marked by TestCase Attribute.</summary>
+        public static void Run<T1, T2, T3, T4, T5>(this TestContext context, Action<T1, T2, T3, T4, T5> assertion)
+        {
+            var type = Assembly.GetCallingAssembly().GetType(context.FullyQualifiedTestClassName);
+            foreach (var parameters in GetParameters(type, context.TestName))
+            {
+                assertion(
+                    (T1)parameters[0],
+                    (T2)parameters[1],
+                    (T3)parameters[2],
+                    (T4)parameters[3],
+                    (T5)parameters[4]
+                    );
+            }
+        }
+
+        /// <summary>Run Parameterized Test marked by TestCase Attribute.</summary>
+        public static void Run<T1, T2, T3, T4, T5, T6>(this TestContext context, Action<T1, T2, T3, T4, T5, T6> assertion)
+        {
+            var type = Assembly.GetCallingAssembly().GetType(context.FullyQualifiedTestClassName);
+            foreach (var parameters in GetParameters(type, context.TestName))
+            {
+                assertion(
+                    (T1)parameters[0],
+                    (T2)parameters[1],
+                    (T3)parameters[2],
+                    (T4)parameters[3],
+                    (T5)parameters[4],
+                    (T6)parameters[5]
+                    );
+            }
+        }
+
+        /// <summary>Run Parameterized Test marked by TestCase Attribute.</summary>
+        public static void Run<T1, T2, T3, T4, T5, T6, T7>(this TestContext context, Action<T1, T2, T3, T4, T5, T6, T7> assertion)
+        {
+            var type = Assembly.GetCallingAssembly().GetType(context.FullyQualifiedTestClassName);
+            foreach (var parameters in GetParameters(type, context.TestName))
+            {
+                assertion(
+                    (T1)parameters[0],
+                    (T2)parameters[1],
+                    (T3)parameters[2],
+                    (T4)parameters[3],
+                    (T5)parameters[4],
+                    (T6)parameters[5],
+                    (T7)parameters[6]
+                    );
+            }
+        }
+
+        /// <summary>Run Parameterized Test marked by TestCase Attribute.</summary>
+        public static void Run<T1, T2, T3, T4, T5, T6, T7, T8>(this TestContext context, Action<T1, T2, T3, T4, T5, T6, T7, T8> assertion)
+        {
+            var type = Assembly.GetCallingAssembly().GetType(context.FullyQualifiedTestClassName);
+            foreach (var parameters in GetParameters(type, context.TestName))
+            {
+                assertion(
+                    (T1)parameters[0],
+                    (T2)parameters[1],
+                    (T3)parameters[2],
+                    (T4)parameters[3],
+                    (T5)parameters[4],
+                    (T6)parameters[5],
+                    (T7)parameters[6],
+                    (T8)parameters[7]
+                    );
+            }
+        }
+
+        /// <summary>Run Parameterized Test marked by TestCase Attribute.</summary>
+        public static void Run<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this TestContext context, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9> assertion)
+        {
+            var type = Assembly.GetCallingAssembly().GetType(context.FullyQualifiedTestClassName);
+            foreach (var parameters in GetParameters(type, context.TestName))
+            {
+                assertion(
+                    (T1)parameters[0],
+                    (T2)parameters[1],
+                    (T3)parameters[2],
+                    (T4)parameters[3],
+                    (T5)parameters[4],
+                    (T6)parameters[5],
+                    (T7)parameters[6],
+                    (T8)parameters[7],
+                    (T9)parameters[8]
+                    );
+            }
+        }
+
+        /// <summary>Run Parameterized Test marked by TestCase Attribute.</summary>
+        public static void Run<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this TestContext context, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> assertion)
+        {
+            var type = Assembly.GetCallingAssembly().GetType(context.FullyQualifiedTestClassName);
+            foreach (var parameters in GetParameters(type, context.TestName))
+            {
+                assertion(
+                    (T1)parameters[0],
+                    (T2)parameters[1],
+                    (T3)parameters[2],
+                    (T4)parameters[3],
+                    (T5)parameters[4],
+                    (T6)parameters[5],
+                    (T7)parameters[6],
+                    (T8)parameters[7],
+                    (T9)parameters[8],
+                    (T10)parameters[9]
+                    );
+            }
+        }
+
+        /// <summary>Run Parameterized Test marked by TestCase Attribute.</summary>
+        public static void Run<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this TestContext context, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> assertion)
+        {
+            var type = Assembly.GetCallingAssembly().GetType(context.FullyQualifiedTestClassName);
+            foreach (var parameters in GetParameters(type, context.TestName))
+            {
+                assertion(
+                    (T1)parameters[0],
+                    (T2)parameters[1],
+                    (T3)parameters[2],
+                    (T4)parameters[3],
+                    (T5)parameters[4],
+                    (T6)parameters[5],
+                    (T7)parameters[6],
+                    (T8)parameters[7],
+                    (T9)parameters[8],
+                    (T10)parameters[9],
+                    (T11)parameters[10]
+                    );
+            }
+        }
+
+        /// <summary>Run Parameterized Test marked by TestCase Attribute.</summary>
+        public static void Run<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this TestContext context, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> assertion)
+        {
+            var type = Assembly.GetCallingAssembly().GetType(context.FullyQualifiedTestClassName);
+            foreach (var parameters in GetParameters(type, context.TestName))
+            {
+                assertion(
+                    (T1)parameters[0],
+                    (T2)parameters[1],
+                    (T3)parameters[2],
+                    (T4)parameters[3],
+                    (T5)parameters[4],
+                    (T6)parameters[5],
+                    (T7)parameters[6],
+                    (T8)parameters[7],
+                    (T9)parameters[8],
+                    (T10)parameters[9],
+                    (T11)parameters[10],
+                    (T12)parameters[11]
+                    );
+            }
+        }
+
+        /// <summary>Run Parameterized Test marked by TestCase Attribute.</summary>
+        public static void Run<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this TestContext context, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> assertion)
+        {
+            var type = Assembly.GetCallingAssembly().GetType(context.FullyQualifiedTestClassName);
+            foreach (var parameters in GetParameters(type, context.TestName))
+            {
+                assertion(
+                    (T1)parameters[0],
+                    (T2)parameters[1],
+                    (T3)parameters[2],
+                    (T4)parameters[3],
+                    (T5)parameters[4],
+                    (T6)parameters[5],
+                    (T7)parameters[6],
+                    (T8)parameters[7],
+                    (T9)parameters[8],
+                    (T10)parameters[9],
+                    (T11)parameters[10],
+                    (T12)parameters[11],
+                    (T13)parameters[12]
+                    );
+            }
+        }
+
+        /// <summary>Run Parameterized Test marked by TestCase Attribute.</summary>
+        public static void Run<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this TestContext context, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> assertion)
+        {
+            var type = Assembly.GetCallingAssembly().GetType(context.FullyQualifiedTestClassName);
+            foreach (var parameters in GetParameters(type, context.TestName))
+            {
+                assertion(
+                    (T1)parameters[0],
+                    (T2)parameters[1],
+                    (T3)parameters[2],
+                    (T4)parameters[3],
+                    (T5)parameters[4],
+                    (T6)parameters[5],
+                    (T7)parameters[6],
+                    (T8)parameters[7],
+                    (T9)parameters[8],
+                    (T10)parameters[9],
+                    (T11)parameters[10],
+                    (T12)parameters[11],
+                    (T13)parameters[12],
+                    (T14)parameters[13]
+                    );
+            }
+        }
+
+        /// <summary>Run Parameterized Test marked by TestCase Attribute.</summary>
+        public static void Run<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(this TestContext context, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> assertion)
+        {
+            var type = Assembly.GetCallingAssembly().GetType(context.FullyQualifiedTestClassName);
+            foreach (var parameters in GetParameters(type, context.TestName))
+            {
+                assertion(
+                    (T1)parameters[0],
+                    (T2)parameters[1],
+                    (T3)parameters[2],
+                    (T4)parameters[3],
+                    (T5)parameters[4],
+                    (T6)parameters[5],
+                    (T7)parameters[6],
+                    (T8)parameters[7],
+                    (T9)parameters[8],
+                    (T10)parameters[9],
+                    (T11)parameters[10],
+                    (T12)parameters[11],
+                    (T13)parameters[12],
+                    (T14)parameters[13],
+                    (T15)parameters[14]
+                    );
+            }
+        }
+
+        /// <summary>Run Parameterized Test marked by TestCase Attribute.</summary>
+        public static void Run<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(this TestContext context, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> assertion)
+        {
+            var type = Assembly.GetCallingAssembly().GetType(context.FullyQualifiedTestClassName);
+            foreach (var parameters in GetParameters(type, context.TestName))
+            {
+                assertion(
+                    (T1)parameters[0],
+                    (T2)parameters[1],
+                    (T3)parameters[2],
+                    (T4)parameters[3],
+                    (T5)parameters[4],
+                    (T6)parameters[5],
+                    (T7)parameters[6],
+                    (T8)parameters[7],
+                    (T9)parameters[8],
+                    (T10)parameters[9],
+                    (T11)parameters[10],
+                    (T12)parameters[11],
+                    (T13)parameters[12],
+                    (T14)parameters[13],
+                    (T15)parameters[14],
+                    (T16)parameters[15]
+                    );
+            }
+        }
+    }
+
+    #endregion
+}

--- a/ExpeditionListPluginTests/ExpeditionInfoTests.cs
+++ b/ExpeditionListPluginTests/ExpeditionInfoTests.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ExpeditionListPlugin;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ExpeditionListPlugin.Tests
+{
+    [TestClass()]
+    public class ExpeditionInfoTests
+    {
+        [TestMethod()]
+        public void RequireShipTypeTextTest()
+        {
+            var s = ExpeditionInfo._ExpeditionTable[3].RequireShipTypeText;
+            Console.WriteLine(s);
+            s.Is("軽1 駆2 or 駆1 海防3 or 軽1 海防2 or 練1 海防2 or 護母1 海防2 or 護母1 駆2 ");
+
+            s = ExpeditionInfo._ExpeditionTable[8].RequireShipTypeText;
+            Console.WriteLine(s);
+            s.Is("駆,海防合計3");
+
+            s = ExpeditionInfo._ExpeditionTable.First(t => t.EName == "長時間対潜警戒").RequireShipTypeText;
+            Console.WriteLine(s);
+            s.Is("軽1 駆,海防合計3");
+        }
+    }
+}

--- a/ExpeditionListPluginTests/ExpeditionListPluginTests.csproj
+++ b/ExpeditionListPluginTests/ExpeditionListPluginTests.csproj
@@ -1,0 +1,109 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{ED709ABD-DC0B-404F-8B10-CFE5A79A50EE}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ExpeditionListPluginTests</RootNamespace>
+    <AssemblyName>ExpeditionListPluginTests</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.2.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.2.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise />
+  </Choose>
+  <ItemGroup>
+    <Compile Include="ChainingAssertion.MSTest.cs" />
+    <Compile Include="ExpeditionInfoTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ExpeditionListPlugin\ExpeditionListPlugin.csproj">
+      <Project>{C9BA0ACE-71D0-434C-82A9-0C8F7CEC1769}</Project>
+      <Name>ExpeditionListPlugin</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>このプロジェクトは、このコンピューター上にない NuGet パッケージを参照しています。それらのパッケージをダウンロードするには、[NuGet パッケージの復元] を使用します。詳細については、http://go.microsoft.com/fwlink/?LinkID=322105 を参照してください。見つからないファイルは {0} です。</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/ExpeditionListPluginTests/Properties/AssemblyInfo.cs
+++ b/ExpeditionListPluginTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// アセンブリに関する一般情報は以下の属性セットをとおして制御されます。
+// アセンブリに関連付けられている情報を変更するには、
+// これらの属性値を変更してください。
+[assembly: AssemblyTitle("ExpeditionListPluginTests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ExpeditionListPluginTests")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// ComVisible を false に設定すると、その型はこのアセンブリ内で COM コンポーネントから 
+// 参照できなくなります。このアセンブリ内で COM から型にアクセスする必要がある場合は、 
+// その型の ComVisible 属性を true に設定してください。
+[assembly: ComVisible(false)]
+
+// このプロジェクトが COM に公開される場合、次の GUID が typelib の ID になります
+[assembly: Guid("ed709abd-dc0b-404f-8b10-cfe5a79a50ee")]
+
+// アセンブリのバージョン情報は次の 4 つの値で構成されています:
+//
+//      メジャー バージョン
+//      マイナー バージョン
+//      ビルド番号
+//      Revision
+//
+// すべての値を指定するか、以下のように '*' を使用してビルド番号とリビジョン番号を 
+// 既定値にすることができます:
+//[アセンブリ: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/ExpeditionListPluginTests/app.config
+++ b/ExpeditionListPluginTests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.8.0" newVersion="2.0.8.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/ExpeditionListPluginTests/packages.config
+++ b/ExpeditionListPluginTests/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="ChainingAssertion" version="1.7.1.0" targetFramework="net46" />
+  <package id="MSTest.TestAdapter" version="1.2.0" targetFramework="net46" />
+  <package id="MSTest.TestFramework" version="1.2.0" targetFramework="net46" />
+</packages>

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 reniris
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.txt
+++ b/README.txt
@@ -1,0 +1,2 @@
+# ExpeditionListPluginMod
+ExpeditionListPluginの改造版です

--- a/README.txt
+++ b/README.txt
@@ -1,2 +1,4 @@
-# ExpeditionListPluginMod
+﻿# ExpeditionListPluginMod
 ExpeditionListPluginの改造版です
+
+兵站強化任務、海峡警備行動、長時間対潜警戒、南西方面航空偵察作戦の追加に対応しています


### PR DESCRIPTION
兵站強化任務、海峡警備行動、長時間対潜警戒、南西方面航空偵察作戦の追加に対応しています。

「対潜警戒任務」(ID4)、「海上護衛任務」(ID5)、「タンカー護衛任務」(ID9)の3種について
海防艦と護衛空母を用いた既存の組み合わせ(軽巡1/駆逐2or3)と異なる成功パターンにも対応しました。